### PR TITLE
Add buy product

### DIFF
--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/ProductController.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/ProductController.java
@@ -265,9 +265,8 @@ public class ProductController {
     public ResponseEntity<?> deleteProduct(@PathVariable("id") int id) {
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
-    @PostMapping(value = "/buy/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(value = "/{id}/buy", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<?> buyProduct(@PathVariable("id") int productId) {
-        // add logic for budgeting
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 }


### PR DESCRIPTION
A new POST endpoint was added at /api/products/buy/{id} to simulate the purchase of a product. When a request is made to this endpoint with a product ID, the system will (in the future) add the product to the budget.