### PR TITLE
Change AccountReport DTOs From Using IDs to User Data

### DIFF
--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/AccountReportController.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/AccountReportController.java
@@ -24,22 +24,22 @@ public class AccountReportController {
         report1.setId(1);
         report1.setStatus(Status.ACCEPTED);
         report1.setDescription("Reason for reporting 1");
-        report1.setReporterName("User1");
-        report1.setReporteeName("User2");
+        report1.setReporterEmail("User1");
+        report1.setReporteeEmail("User2");
 
         GetAccountReportDTO report2 = new GetAccountReportDTO();
         report2.setId(2);
         report2.setStatus(Status.ACCEPTED);
         report2.setDescription("Reason for reporting 2");
-        report2.setReporterName("User2");
-        report2.setReporteeName("User3");
+        report2.setReporterEmail("User2");
+        report2.setReporteeEmail("User3");
 
         GetAccountReportDTO report3 = new GetAccountReportDTO();
         report3.setId(3);
         report3.setStatus(Status.ACCEPTED);
         report3.setDescription("Reason for reporting 3");
-        report3.setReporterName("User5");
-        report3.setReporteeName("User3");
+        report3.setReporterEmail("User5");
+        report3.setReporteeEmail("User3");
 
         reports.add(report1);
         reports.add(report2);
@@ -55,8 +55,8 @@ public class AccountReportController {
         report.setId(id);
         report.setStatus(Status.PENDING);
         report.setDescription("Reason for reporting 1");
-        report.setReporterName("User1");
-        report.setReporteeName("User2");
+        report.setReporterEmail("User1");
+        report.setReporteeEmail("User2");
 
         return new ResponseEntity<>(report, HttpStatus.OK);
     }
@@ -67,8 +67,8 @@ public class AccountReportController {
         createdReport.setId(1);
         createdReport.setStatus(Status.PENDING);
         createdReport.setDescription(report.getDescription());
-        createdReport.setReporterName(report.getReporterName());
-        createdReport.setReporteeName(report.getReporteeName());
+        createdReport.setReporterEmail(report.getReporterEmail());
+        createdReport.setReporteeEmail(report.getReporteeEmail());
 
         return new ResponseEntity<CreatedAccountReportDTO>(createdReport, HttpStatus.CREATED);
     }

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/dto/CreateAccountReportDTO.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/dto/CreateAccountReportDTO.java
@@ -7,8 +7,8 @@ import lombok.Setter;
 @Setter
 public class CreateAccountReportDTO {
     private String description;
-    private String reporterName;
-    private String reporteeName;
+    private String reporterEmail;
+    private String reporteeEmail;
 
     public CreateAccountReportDTO() {
     }

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/dto/CreatedAccountReportDTO.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/dto/CreatedAccountReportDTO.java
@@ -10,8 +10,8 @@ public class CreatedAccountReportDTO {
     private int id;
     private String description;
     private Status status;
-    private String reporterName;
-    private String reporteeName;
+    private String reporterEmail;
+    private String reporteeEmail;
 
     public CreatedAccountReportDTO() {
     }

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/dto/GetAccountReportDTO.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/dto/GetAccountReportDTO.java
@@ -11,8 +11,8 @@ public class GetAccountReportDTO
     private int id;
     private String description;
     private Status status;
-    private String reporterName;
-    private String reporteeName;
+    private String reporterEmail;
+    private String reporteeEmail;
 
     public GetAccountReportDTO() {
     }


### PR DESCRIPTION
Made a switch requested at checkpoint one, instead of getting/creating account reports with users IDs, instead the names of reporter and reportee are being used, which will be useful for admin panel.