### PR TITLE
Remove offering details and add service and product details

### DIFF
--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/model/Product.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/model/Product.java
@@ -1,23 +1,23 @@
 package com.ftn.iss.eventPlanner.model;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
 import java.util.HashSet;
 import java.util.Set;
-import jakarta.persistence.CascadeType;
+
 @Getter
 @Setter
 @Entity
+@AllArgsConstructor
 public class Product extends Offering {
     @OneToOne(cascade = CascadeType.ALL)
-    private OfferingDetails currentDetails;
+    @JoinColumn(name = "current_product_details_id")
+    private ProductDetails currentDetails;
     @OneToMany(cascade = CascadeType.ALL)
-    private Set<OfferingDetails> detailsHistory = new HashSet<>();
+    private Set<ProductDetails> detailsHistory = new HashSet<>();
 
     public Product() {
     }

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/model/ProductDetails.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/model/ProductDetails.java
@@ -1,0 +1,42 @@
+package com.ftn.iss.eventPlanner.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Getter
+@Setter
+@Entity
+@AllArgsConstructor
+public class ProductDetails {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+    @Column(nullable = false)
+    private String name;
+    @Column(nullable = false)
+    private String description;
+    @Column(nullable = false)
+    private double price;
+    @Column
+    private double discount;
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "offering_details_photos", joinColumns = @JoinColumn(name = "offerin_details_id"))
+    @Column(name = "photo_url")
+    private Set<String> photos = new HashSet<>();;
+    @Column(nullable = false)
+    private boolean isVisible;
+    @Column(nullable = false)
+    private boolean isAvailable;
+    @Column(nullable = false)
+    private LocalDateTime timestamp;
+    public ProductDetails() {
+    }
+
+}

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/model/Service.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/model/Service.java
@@ -1,22 +1,22 @@
 package com.ftn.iss.eventPlanner.model;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
-
 import java.util.HashSet;
 import java.util.Set;
-import jakarta.persistence.CascadeType;
+
 @Getter
 @Setter
 @Entity
-public class Service extends Offering{
+@AllArgsConstructor
+public class Service extends Offering {
     @OneToOne(cascade = CascadeType.ALL)
-    private OfferingDetails currentDetails;
+    @JoinColumn(name = "current_service_details_id")
+    private ServiceDetails currentDetails;
     @OneToMany(cascade = CascadeType.ALL)
-    private Set<OfferingDetails> detailsHistory = new HashSet<>();
+    private Set<ServiceDetails> detailsHistory = new HashSet<>();
 
     public Service() {
     }

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/model/ServiceDetails.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/model/ServiceDetails.java
@@ -5,15 +5,14 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.util.HashSet;
-import java.util.Set;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Setter
 @AllArgsConstructor
 @Entity
-public class OfferingDetails {
+public class ServiceDetails {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
@@ -30,16 +29,16 @@ public class OfferingDetails {
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "offering_details_photos", joinColumns = @JoinColumn(name = "offerin_details_id"))
     @Column(name = "photo_url")
-    private Set<String> photos = new HashSet<>();
-    @Column
+    private List<String> photos;
+    @Column(nullable = false)
     private boolean fixedTime;
-    @Column
+    @Column(nullable = false)
     private int maxDuration;
-    @Column
+    @Column(nullable = false)
     private int minDuration;
-    @Column
+    @Column(nullable = false)
     private int cancellationPeriod;
-    @Column
+    @Column(nullable = false)
     private int reservationPeriod;
     @Column(nullable = false)
     private boolean isVisible;
@@ -50,7 +49,6 @@ public class OfferingDetails {
     @Column(nullable = false)
     private LocalDateTime timestamp;
 
-    public OfferingDetails() {
+    public ServiceDetails() {
     }
-
 }


### PR DESCRIPTION
This PR refactors the entity model for offerings in the Event Planner application, addressing relationship mapping issues between offerings (Services and Products) and their details.

## Key Changes
1. Added specific `@JoinColumn` annotations for Service and Product entities.
2. Improved cascade persistence for offering details.
3. Clearer relational annotations between offerings and their details.
4. Prevent errors when saving entities with details.
5. Better organization and separation of different offering types.
