### PR TITLE
Add Offering Category Management Functionality

### DIFF
--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/OfferingCategoryController.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/OfferingCategoryController.java
@@ -1,0 +1,83 @@
+package com.ftn.iss.eventPlanner.controller;
+
+import com.ftn.iss.eventPlanner.dto.PagedResponse;
+import com.ftn.iss.eventPlanner.dto.offeringcategory.*;
+import com.ftn.iss.eventPlanner.services.OfferingCategoryService;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.data.web.SpringDataWebProperties;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/categories")
+public class OfferingCategoryController {
+    @Autowired
+    private OfferingCategoryService offeringCategoryService;
+    @GetMapping(value = "/all", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Collection<GetOfferingCategoryDTO>> getCategories(){
+        List<GetOfferingCategoryDTO> categories = offeringCategoryService.findAll();
+        return new ResponseEntity<>(categories, HttpStatus.OK);
+    }
+    @GetMapping( produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<PagedResponse<GetOfferingCategoryDTO>> getCategoriesPage(SpringDataWebProperties.Pageable page) {
+        Collection<GetOfferingCategoryDTO> categories = new ArrayList<>() ;
+
+        PagedResponse<GetOfferingCategoryDTO> response = new PagedResponse<>(
+                categories,
+                1,
+                5
+        );
+
+        return new ResponseEntity<PagedResponse<GetOfferingCategoryDTO>>(response, HttpStatus.OK);
+    }
+    @GetMapping(value = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<GetOfferingCategoryDTO> getCategory(@PathVariable("id") int id) {
+        try {
+            GetOfferingCategoryDTO offeringCategoryDTO = offeringCategoryService.findById(id);
+            return new ResponseEntity<>(offeringCategoryDTO, HttpStatus.OK);
+        } catch (IllegalArgumentException e) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+    }
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<CreatedOfferingCategoryDTO> createCategory(@Valid @RequestBody CreateOfferingCategoryDTO category) throws Exception {
+        try{
+            CreatedOfferingCategoryDTO createdOfferingCategoryDTO = offeringCategoryService.create(category);
+            return new ResponseEntity<>(createdOfferingCategoryDTO, HttpStatus.CREATED);
+        }
+        catch (IllegalArgumentException e){
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
+    }
+    @PutMapping(value = "/{id}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<UpdatedOfferingCategoryDTO> updateCategory(@RequestBody UpdateOfferingCategoryDTO category, @PathVariable int id)
+            throws Exception {
+        try{
+            UpdatedOfferingCategoryDTO updatedOfferingCategoryDTO = offeringCategoryService.update(id,category);
+            return new ResponseEntity<>(updatedOfferingCategoryDTO, HttpStatus.CREATED);
+        }
+        catch (IllegalArgumentException e){
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }}
+
+    /*
+    TODO: delete only if there are no offerings
+     */
+    @DeleteMapping(value = "/{id}")
+    public ResponseEntity<?> delete(@PathVariable("id") int id) {
+        try {
+            offeringCategoryService.delete(id);
+            return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+        } catch (IllegalArgumentException e) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+    }
+}

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/dto/offeringcategory/CreateOfferingCategoryDTO.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/dto/offeringcategory/CreateOfferingCategoryDTO.java
@@ -1,0 +1,14 @@
+package com.ftn.iss.eventPlanner.dto.offeringcategory;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CreateOfferingCategoryDTO {
+    private String name;
+    private String description;
+    public CreateOfferingCategoryDTO(){
+
+    }
+}

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/dto/offeringcategory/CreatedOfferingCategoryDTO.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/dto/offeringcategory/CreatedOfferingCategoryDTO.java
@@ -1,0 +1,10 @@
+package com.ftn.iss.eventPlanner.dto.offeringcategory;
+
+public class CreatedOfferingCategoryDTO {
+    private int id;
+    private String name;
+    private String description;
+    public CreatedOfferingCategoryDTO(){
+
+    }
+}

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/dto/offeringcategory/UpdateOfferingCategoryDTO.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/dto/offeringcategory/UpdateOfferingCategoryDTO.java
@@ -8,6 +8,6 @@ import lombok.Setter;
 @Setter
 public class UpdateOfferingCategoryDTO {
     private String name;
-    private Status description;
+    private String description;
     public UpdateOfferingCategoryDTO(){}
 }

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/dto/offeringcategory/UpdateOfferingCategoryDTO.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/dto/offeringcategory/UpdateOfferingCategoryDTO.java
@@ -1,0 +1,13 @@
+package com.ftn.iss.eventPlanner.dto.offeringcategory;
+
+import com.ftn.iss.eventPlanner.model.Status;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UpdateOfferingCategoryDTO {
+    private String name;
+    private Status description;
+    public UpdateOfferingCategoryDTO(){}
+}

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/dto/offeringcategory/UpdatedOfferingCategoryDTO.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/dto/offeringcategory/UpdatedOfferingCategoryDTO.java
@@ -1,0 +1,14 @@
+package com.ftn.iss.eventPlanner.dto.offeringcategory;
+
+import com.ftn.iss.eventPlanner.model.Status;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UpdatedOfferingCategoryDTO {
+    private int id;
+    private String name;
+    private Status description;
+    public UpdatedOfferingCategoryDTO(){}
+}

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/dto/offeringcategory/UpdatedOfferingCategoryDTO.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/dto/offeringcategory/UpdatedOfferingCategoryDTO.java
@@ -9,6 +9,6 @@ import lombok.Setter;
 public class UpdatedOfferingCategoryDTO {
     private int id;
     private String name;
-    private Status description;
+    private String description;
     public UpdatedOfferingCategoryDTO(){}
 }

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/services/OfferingCategoryService.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/services/OfferingCategoryService.java
@@ -1,0 +1,56 @@
+package com.ftn.iss.eventPlanner.services;
+
+import com.ftn.iss.eventPlanner.dto.eventtype.*;
+import com.ftn.iss.eventPlanner.dto.offeringcategory.*;
+import com.ftn.iss.eventPlanner.model.EventType;
+import com.ftn.iss.eventPlanner.model.OfferingCategory;
+import com.ftn.iss.eventPlanner.repositories.OfferingCategoryRepository;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+@Service
+
+public class OfferingCategoryService {
+    @Autowired
+    private OfferingCategoryRepository offeringCategoryRepository;
+    @Autowired
+    private ModelMapper modelMapper = new ModelMapper();
+
+    public List<GetOfferingCategoryDTO> findAll(){
+        List<OfferingCategory> offeringCategorys = offeringCategoryRepository.findAll();
+        return offeringCategorys.stream()
+                .map(offeringCategory -> modelMapper.map(offeringCategory, GetOfferingCategoryDTO.class))
+                .collect(Collectors.toList());
+    }
+    public GetOfferingCategoryDTO findById(int id) {
+        OfferingCategory category = offeringCategoryRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Event Type with ID " + id + " not found"));
+        return modelMapper.map(category, GetOfferingCategoryDTO.class);
+    }
+    public CreatedOfferingCategoryDTO create(CreateOfferingCategoryDTO createOfferingCategoryDTO){
+        OfferingCategory offeringCategory = new OfferingCategory();
+        modelMapper.map(createOfferingCategoryDTO,offeringCategory);
+        offeringCategory.setDeleted(false);
+        offeringCategory.setPending(true);
+        offeringCategory = offeringCategoryRepository.save(offeringCategory);
+        return modelMapper.map(offeringCategory,CreatedOfferingCategoryDTO.class);
+    }
+    public UpdatedOfferingCategoryDTO update(int id, UpdateOfferingCategoryDTO updateEventTypeDTO) {
+        OfferingCategory offeringCategory = offeringCategoryRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Category with ID " + id + " not found"));
+
+        modelMapper.map(updateEventTypeDTO, offeringCategory);
+        offeringCategory = offeringCategoryRepository.save(offeringCategory);
+        return modelMapper.map(offeringCategory, UpdatedOfferingCategoryDTO.class);
+    }
+
+    public void delete(int id) {
+        OfferingCategory offeringCategory = offeringCategoryRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Category with ID " + id + " not found"));
+        offeringCategory.setDeleted(true);
+        offeringCategoryRepository.save(offeringCategory);
+    }
+}


### PR DESCRIPTION
This PR introduces functionality for managing offering categories within the application.  
It includes the creation, retrieval, update, and deletion of offering categories, allowing users to interact with categories via the appropriate endpoints.

## Key Features

### Create Offering Category
- Allows creating new offering categories using `CreateOfferingCategoryDTO`.
- Returns a `CreatedOfferingCategoryDTO` with the details of the newly created category.

### Retrieve Offering Categories
- Fetch all offering categories with the `/all` endpoint, returning a list of `GetOfferingCategoryDTO` objects.
- Support for paginated results with the `/` endpoint, using `PagedResponse<GetOfferingCategoryDTO>`.
- Fetch a specific offering category by ID, returning a `GetOfferingCategoryDTO`.

### Update Offering Category
- Update an existing offering category by providing an `UpdateOfferingCategoryDTO` and the category ID.
- Returns an `UpdatedOfferingCategoryDTO` with the updated category details.

### Delete Offering Category
- Soft delete an offering category by marking it as deleted.