### PR TITLE
Add Approve Method for Category

### DIFF
--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/OfferingCategoryController.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/OfferingCategoryController.java
@@ -68,4 +68,13 @@ public class OfferingCategoryController {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }
     }
+    @PutMapping(value = "/{id}/approve")
+    public ResponseEntity<Void> approve(@PathVariable int id) {
+        try {
+            offeringCategoryService.approve(id);
+            return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+        } catch (IllegalArgumentException e) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+    }
 }

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/OfferingCategoryController.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/OfferingCategoryController.java
@@ -15,28 +15,16 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-
+@CrossOrigin
 @RestController
 @RequestMapping("/api/categories")
 public class OfferingCategoryController {
     @Autowired
     private OfferingCategoryService offeringCategoryService;
-    @GetMapping(value = "/all", produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Collection<GetOfferingCategoryDTO>> getCategories(){
         List<GetOfferingCategoryDTO> categories = offeringCategoryService.findAll();
         return new ResponseEntity<>(categories, HttpStatus.OK);
-    }
-    @GetMapping( produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<PagedResponse<GetOfferingCategoryDTO>> getCategoriesPage(SpringDataWebProperties.Pageable page) {
-        Collection<GetOfferingCategoryDTO> categories = new ArrayList<>() ;
-
-        PagedResponse<GetOfferingCategoryDTO> response = new PagedResponse<>(
-                categories,
-                1,
-                5
-        );
-
-        return new ResponseEntity<PagedResponse<GetOfferingCategoryDTO>>(response, HttpStatus.OK);
     }
     @GetMapping(value = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<GetOfferingCategoryDTO> getCategory(@PathVariable("id") int id) {

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/dto/offeringcategory/CreatedOfferingCategoryDTO.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/dto/offeringcategory/CreatedOfferingCategoryDTO.java
@@ -1,5 +1,10 @@
 package com.ftn.iss.eventPlanner.dto.offeringcategory;
 
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
 public class CreatedOfferingCategoryDTO {
     private int id;
     private String name;

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/services/OfferingCategoryService.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/services/OfferingCategoryService.java
@@ -54,4 +54,10 @@ public class OfferingCategoryService {
         offeringCategory.setDeleted(true);
         offeringCategoryRepository.save(offeringCategory);
     }
+    public void approve(int id){
+        OfferingCategory offeringCategory = offeringCategoryRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Category with ID " + id + " not found"));
+        offeringCategory.setPending(false);
+        offeringCategoryRepository.save(offeringCategory);
+    }
 }

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/services/OfferingCategoryService.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/services/OfferingCategoryService.java
@@ -17,7 +17,7 @@ public class OfferingCategoryService {
     @Autowired
     private OfferingCategoryRepository offeringCategoryRepository;
     @Autowired
-    private ModelMapper modelMapper = new ModelMapper();
+    private ModelMapper modelMapper;
 
     public List<GetOfferingCategoryDTO> findAll(){
         List<OfferingCategory> offeringCategorys = offeringCategoryRepository.findAll();
@@ -28,7 +28,7 @@ public class OfferingCategoryService {
 
     public GetOfferingCategoryDTO findById(int id) {
         OfferingCategory category = offeringCategoryRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("Event Type with ID " + id + " not found"));
+                .orElseThrow(() -> new IllegalArgumentException("Category with ID " + id + " not found"));
         return modelMapper.map(category, GetOfferingCategoryDTO.class);
     }
     public CreatedOfferingCategoryDTO create(CreateOfferingCategoryDTO createOfferingCategoryDTO){

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/services/OfferingService.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/services/OfferingService.java
@@ -184,7 +184,7 @@ public class OfferingService {
             // TO BE CHANGED WHEN PHOTOS ATTRIBUTE IS CHANGED TO A SET
             Set<String> photos = pr.getCurrentDetails().getPhotos();
             if (photos != null && !photos.isEmpty()) {
-                String coverPicture = new ArrayList<>(photos).getFirst();
+                String coverPicture = new ArrayList<>(photos).get(0);
                 dto.setCoverPicture(coverPicture);
             }
             dto.setIsService(false);
@@ -195,7 +195,7 @@ public class OfferingService {
             dto.setPrice(service.getCurrentDetails().getPrice());
             List<String> photos = service.getCurrentDetails().getPhotos();
             if (photos != null && !photos.isEmpty()) {
-                String coverPicture = new ArrayList<>(photos).getFirst();
+                String coverPicture = new ArrayList<>(photos).get(0);
                 dto.setCoverPicture(coverPicture);
             }
             dto.setIsService(true);


### PR DESCRIPTION
This pull request adds a new method, `approve`, in the backend service responsible for managing categories.  
The method allows marking a category as approved by setting its `pending` field to `false`.  
It ensures that categories are correctly updated in the database when they are approved.

## `approve` Method
- Takes the category ID as a parameter.
- Retrieves the category from the database using `offeringCategoryRepository.findById(id)`.
- Throws `IllegalArgumentException` if the category is not found.
- Updates the `pending` status of the category to `false` via `offeringCategory.setPending(false)`.
- Saves the updated category back to the repository using `offeringCategoryRepository.save(offeringCategory)`.

## Logic
- Ensures that only valid categories are approved.
- Attempts to approve a non-existent category result in an appropriate error message.
- Critical for managing category state and enabling further processing of approved categories.
