### PR TITLE
Add PDF export functionality for pricelist

### DIFF
--- a/eventPlanner/pom.xml
+++ b/eventPlanner/pom.xml
@@ -51,7 +51,13 @@
 			<version>1.6.15</version>
 		</dependency>
 
-	<dependency>
+		<dependency>
+			<groupId>net.sf.jasperreports</groupId>
+			<artifactId>jasperreports</artifactId>
+			<version>6.20.0</version>
+		</dependency>
+
+		<dependency>
 		<groupId>io.jsonwebtoken</groupId>
 		<artifactId>jjwt</artifactId>
 		<version>0.9.1</version>

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/PricelistController.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/PricelistController.java
@@ -26,7 +26,7 @@ import java.util.NoSuchElementException;
 
 @CrossOrigin
 @RestController
-@RequestMapping("/api/pricelist")
+@RequestMapping("/api/pricelists")
 public class PricelistController {
     @Autowired
 

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/ReportController.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/ReportController.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 @CrossOrigin
 @RestController
-@RequestMapping("/api/report")
+@RequestMapping("/api/reports")
 public class ReportController {
 
     @Autowired
@@ -26,23 +26,10 @@ public class ReportController {
     @Autowired
     private OfferingService offeringService;
 
-    @GetMapping(value = "/pricelist", produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(value = "/pricelists", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<byte[]> generateReport() {
         try {
-            List<GetOfferingDTO> pricelistItems = offeringService.findAll();
-            List<GetPricelistItemDTO> pricelist = new ArrayList<>();
-
-            for (GetOfferingDTO offering : pricelistItems) {
-                GetPricelistItemDTO item = new GetPricelistItemDTO();
-                item.setId(offering.getId());
-                item.setOfferingId(offering.getId());
-                item.setName(offering.getName());
-                item.setPrice(offering.getPrice());
-                item.setDiscount(offering.getDiscount());
-                double priceWithDiscount = offering.getPrice() * (1 - offering.getDiscount()/100);
-                item.setPriceWithDiscount(priceWithDiscount);
-                pricelist.add(item);
-            }
+            List<GetPricelistItemDTO> pricelist = reportService.getPricelist();
             byte[] pdfReport = reportService.generateReport(pricelist);
             return ResponseEntity.ok()
                     .header("Content-Type", "application/pdf")

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/ReportController.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/ReportController.java
@@ -1,0 +1,56 @@
+package com.ftn.iss.eventPlanner.controller;
+
+import com.ftn.iss.eventPlanner.dto.offering.GetOfferingDTO;
+import com.ftn.iss.eventPlanner.dto.pricelistitem.GetPricelistItemDTO;
+import com.ftn.iss.eventPlanner.services.OfferingService;
+import com.ftn.iss.eventPlanner.services.PricelistReportService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+@CrossOrigin
+@RestController
+@RequestMapping("/api/report")
+public class ReportController {
+
+    @Autowired
+    private PricelistReportService reportService;
+    @Autowired
+    private OfferingService offeringService;
+
+    @GetMapping(value = "/pricelist", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<byte[]> generateReport() {
+        try {
+            List<GetOfferingDTO> pricelistItems = offeringService.findAll();
+            List<GetPricelistItemDTO> pricelist = new ArrayList<>();
+
+            for (GetOfferingDTO offering : pricelistItems) {
+                GetPricelistItemDTO item = new GetPricelistItemDTO();
+                item.setId(offering.getId());
+                item.setOfferingId(offering.getId());
+                item.setName(offering.getName());
+                item.setPrice(offering.getPrice());
+                item.setDiscount(offering.getDiscount());
+                double priceWithDiscount = offering.getPrice() * (1 - offering.getDiscount()/100);
+                item.setPriceWithDiscount(priceWithDiscount);
+                pricelist.add(item);
+            }
+            byte[] pdfReport = reportService.generateReport(pricelist);
+            return ResponseEntity.ok()
+                    .header("Content-Type", "application/pdf")
+                    .header("Content-Disposition", "inline; filename=pricelist_report.pdf")
+                    .body(pdfReport);
+        } catch (Exception e) {
+            return ResponseEntity.status(500).body(null);
+        }
+    }
+}
+

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/services/PricelistReportService.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/services/PricelistReportService.java
@@ -1,0 +1,48 @@
+package com.ftn.iss.eventPlanner.services;
+
+import com.ftn.iss.eventPlanner.dto.pricelistitem.GetPricelistItemDTO;
+import net.sf.jasperreports.engine.*;
+import net.sf.jasperreports.engine.data.JRBeanCollectionDataSource;
+import org.springframework.stereotype.Service;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.HashMap;
+
+@Service
+public class PricelistReportService {
+
+    public byte[] generateReport(List<GetPricelistItemDTO> pricelistItems) throws JRException {
+        // Load the JRXML template from classpath
+        String reportPath = "template/pricelist_report.jrxml";  // Note: no leading slash
+        InputStream reportStream = getClass().getClassLoader().getResourceAsStream(reportPath);
+        if (reportStream == null) {
+            throw new JRException("Could not find report template: " + reportPath);
+        }
+
+        JasperReport jasperReport = JasperCompileManager.compileReport(reportStream);
+
+        // Prepare the data for the report
+        List<HashMap<String, Object>> reportData = new ArrayList<>();
+        for (GetPricelistItemDTO item : pricelistItems) {
+            HashMap<String, Object> data = new HashMap<>();
+            data.put("serialNumber", item.getId());
+            data.put("itemName", item.getName());
+            data.put("price", item.getPrice());
+            data.put("discount", item.getDiscount());
+            data.put("priceWithDiscount", item.getPriceWithDiscount());
+            reportData.add(data);
+        }
+
+        // Convert data into JRDataSource
+        JRDataSource jrDataSource = new JRBeanCollectionDataSource(reportData);
+
+        // Fill the report with data
+        JasperPrint jasperPrint = JasperFillManager.fillReport(jasperReport, new HashMap<>(), jrDataSource);
+
+        // Export to PDF
+        byte[] pdfReport = JasperExportManager.exportReportToPdf(jasperPrint);
+        return pdfReport;
+    }
+}

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/services/PricelistReportService.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/services/PricelistReportService.java
@@ -1,8 +1,10 @@
 package com.ftn.iss.eventPlanner.services;
 
+import com.ftn.iss.eventPlanner.dto.offering.GetOfferingDTO;
 import com.ftn.iss.eventPlanner.dto.pricelistitem.GetPricelistItemDTO;
 import net.sf.jasperreports.engine.*;
 import net.sf.jasperreports.engine.data.JRBeanCollectionDataSource;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.io.InputStream;
@@ -12,6 +14,26 @@ import java.util.HashMap;
 
 @Service
 public class PricelistReportService {
+    @Autowired
+    OfferingService offeringService;
+    public List<GetPricelistItemDTO> getPricelist() {
+        List<GetOfferingDTO> offerings = offeringService.findAll();
+        List<GetPricelistItemDTO> pricelist = new ArrayList<>();
+
+        for (GetOfferingDTO offering : offerings) {
+            GetPricelistItemDTO item = new GetPricelistItemDTO();
+            item.setId(offering.getId());
+            item.setOfferingId(offering.getId());
+            item.setName(offering.getName());
+            item.setPrice(offering.getPrice());
+            item.setDiscount(offering.getDiscount());
+            double priceWithDiscount = offering.getPrice() * (1 - offering.getDiscount() / 100.0);
+            item.setPriceWithDiscount(priceWithDiscount);
+            pricelist.add(item);
+        }
+
+        return pricelist;
+    }
 
     public byte[] generateReport(List<GetPricelistItemDTO> pricelistItems) throws JRException {
         // Load the JRXML template from classpath

--- a/eventPlanner/src/main/resources/template/pricelist_report.jrxml
+++ b/eventPlanner/src/main/resources/template/pricelist_report.jrxml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports"
+              xmlns:x="http://jasperreports.sourceforge.net/jasperreports/extension"
+              name="Pricelist Report" pageWidth="595" pageHeight="842" columnWidth="515" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20">
+
+    <field name="serialNumber" class="java.lang.Integer"/>
+    <field name="itemName" class="java.lang.String"/>
+    <field name="price" class="java.lang.Double"/>
+    <field name="discount" class="java.lang.Double"/>
+    <field name="priceWithDiscount" class="java.lang.Double"/>
+
+    <!-- Column Header Section -->
+    <columnHeader>
+        <band height="20">
+            <!-- Column Headers -->
+            <textField>
+                <reportElement x="0" y="0" width="50" height="20"/>
+                <textFieldExpression><![CDATA["Serial Number"]]></textFieldExpression>
+            </textField>
+            <textField>
+                <reportElement x="60" y="0" width="200" height="20"/>
+                <textFieldExpression><![CDATA["Item Name"]]></textFieldExpression>
+            </textField>
+            <textField>
+                <reportElement x="270" y="0" width="100" height="20"/>
+                <textFieldExpression><![CDATA["Price"]]></textFieldExpression>
+            </textField>
+            <textField>
+                <reportElement x="380" y="0" width="100" height="20"/>
+                <textFieldExpression><![CDATA["Discount"]]></textFieldExpression>
+            </textField>
+            <textField>
+                <reportElement x="490" y="0" width="100" height="20"/>
+                <textFieldExpression><![CDATA["Price with Discount"]]></textFieldExpression>
+            </textField>
+        </band>
+    </columnHeader>
+
+    <!-- Detail Section (the actual data rows) -->
+    <detail>
+        <band height="20">
+            <textField>
+                <reportElement x="0" y="0" width="50" height="20"/>
+                <textFieldExpression><![CDATA[$F{serialNumber}]]></textFieldExpression>
+            </textField>
+            <textField>
+                <reportElement x="60" y="0" width="200" height="20"/>
+                <textFieldExpression><![CDATA[$F{itemName}]]></textFieldExpression>
+            </textField>
+            <textField>
+                <reportElement x="270" y="0" width="100" height="20"/>
+                <textFieldExpression><![CDATA[$F{price}]]></textFieldExpression>
+            </textField>
+            <textField>
+                <reportElement x="380" y="0" width="100" height="20"/>
+                <textFieldExpression><![CDATA[$F{discount}]]></textFieldExpression>
+            </textField>
+            <textField>
+                <reportElement x="490" y="0" width="100" height="20"/>
+                <textFieldExpression><![CDATA[$F{priceWithDiscount}]]></textFieldExpression>
+            </textField>
+        </band>
+    </detail>
+
+</jasperReport>


### PR DESCRIPTION
This PR implements PDF export functionality for the pricelist using JasperReports.  
Users can now download the pricelist as a formatted PDF document.


## Changes Made
- Added JasperReports dependency to `pom.xml`.
- Created `PricelistReportService` to handle PDF generation.
- Added JRXML template for pricelist report layout.
- Moved template file to `resources` directory for proper classpath access.


## PDF Report Includes
- Serial number
- Item name
- Original price
- Discount percentage
- Final price with discount


## Technical Details
- Uses `JRBeanCollectionDataSource` for data binding.
- Loads template from classpath resources.
- Returns byte array for direct HTTP response.
- Maintains consistent formatting across exports.


## Testing
- Verified PDF generation with sample data.
- Checked proper alignment and data display.
- Confirmed correct calculation of discounted prices.
