### PR TITLE
Implement calendar

### DIFF
--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/config/WebSecurityConfig.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/config/WebSecurityConfig.java
@@ -91,6 +91,7 @@ public class WebSecurityConfig {
                         "api/categories*","api/categories/*",
                         "api/offerings*","api/offerings/*",
                         "api/accounts/*/favourite-events","api/accounts/*/favourite-events/*",
+                        "api/accounts/*/calendar",
                         "api/accounts/*/favourite-offerings","api/accounts/*/favourite-offerings/*",
                         "/socket/**",
                         "api/messages/*/*",

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/config/WebSecurityConfig.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/config/WebSecurityConfig.java
@@ -91,7 +91,6 @@ public class WebSecurityConfig {
                         "api/categories*","api/categories/*",
                         "api/offerings*","api/offerings/*",
                         "api/accounts/*/favourite-events","api/accounts/*/favourite-events/*",
-                        "api/accounts/*/calendar",
                         "api/accounts/*/favourite-offerings","api/accounts/*/favourite-offerings/*",
                         "/socket/**",
                         "api/messages/*/*",

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/AccountController.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/AccountController.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Collection;
@@ -66,6 +67,7 @@ public class AccountController {
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
+    @PreAuthorize("hasAnyAuthority('EVENT_ORGANIZER','PROVIDER', 'ADMIN', 'AUTHENTICATED_USER')")
     @GetMapping(value="/{accountId}/calendar", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Collection<GetCalendarItemDTO>> getCalendar(@PathVariable int accountId) {
         Collection<GetCalendarItemDTO> calendar = accountService.getCalendar(accountId);

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/AccountController.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/AccountController.java
@@ -1,6 +1,7 @@
 package com.ftn.iss.eventPlanner.controller;
 
 import com.ftn.iss.eventPlanner.dto.PagedResponse;
+import com.ftn.iss.eventPlanner.dto.calendaritem.GetCalendarItemDTO;
 import com.ftn.iss.eventPlanner.dto.event.AddFavouriteEventDTO;
 import com.ftn.iss.eventPlanner.dto.event.GetEventDTO;
 import com.ftn.iss.eventPlanner.dto.offering.GetOfferingDTO;
@@ -63,5 +64,11 @@ public class AccountController {
     public ResponseEntity<?> removeOfferingFromFavourites(@PathVariable int accountId, @PathVariable int offeringId) {
         accountService.removeOfferingFromFavourites(accountId, offeringId);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+    @GetMapping(value="/{accountId}/calendar", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Collection<GetCalendarItemDTO>> getCalendar(@PathVariable int accountId) {
+        Collection<GetCalendarItemDTO> calendar = accountService.getCalendar(accountId);
+        return ResponseEntity.ok(calendar);
     }
 }

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/dto/calendaritem/GetCalendarItemDTO.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/dto/calendaritem/GetCalendarItemDTO.java
@@ -1,0 +1,64 @@
+package com.ftn.iss.eventPlanner.dto.calendaritem;
+
+import com.ftn.iss.eventPlanner.model.CalendarItemType;
+
+import java.time.LocalDateTime;
+
+public class GetCalendarItemDTO {
+    private String title;
+    private int eventId;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+    private CalendarItemType type;
+
+    public GetCalendarItemDTO() {
+    }
+
+    public GetCalendarItemDTO(String title, int eventId, LocalDateTime startTime, LocalDateTime endTime, CalendarItemType type) {
+        this.title = title;
+        this.eventId = eventId;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.type = type;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public int getEventId() {
+        return eventId;
+    }
+
+    public void setEventId(int eventId) {
+        this.eventId = eventId;
+    }
+
+    public LocalDateTime getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(LocalDateTime startTime) {
+        this.startTime = startTime;
+    }
+
+    public LocalDateTime getEndTime() {
+        return endTime;
+    }
+
+    public void setEndTime(LocalDateTime endTime) {
+        this.endTime = endTime;
+    }
+
+    public CalendarItemType getType() {
+        return type;
+    }
+
+    public void setType(CalendarItemType type) {
+        this.type = type;
+    }
+}

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/dto/calendaritem/GetCalendarItemDTO.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/dto/calendaritem/GetCalendarItemDTO.java
@@ -1,64 +1,21 @@
 package com.ftn.iss.eventPlanner.dto.calendaritem;
 
 import com.ftn.iss.eventPlanner.model.CalendarItemType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class GetCalendarItemDTO {
     private String title;
     private int eventId;
     private LocalDateTime startTime;
     private LocalDateTime endTime;
     private CalendarItemType type;
-
-    public GetCalendarItemDTO() {
-    }
-
-    public GetCalendarItemDTO(String title, int eventId, LocalDateTime startTime, LocalDateTime endTime, CalendarItemType type) {
-        this.title = title;
-        this.eventId = eventId;
-        this.startTime = startTime;
-        this.endTime = endTime;
-        this.type = type;
-    }
-
-    public String getTitle() {
-        return title;
-    }
-
-    public void setTitle(String title) {
-        this.title = title;
-    }
-
-    public int getEventId() {
-        return eventId;
-    }
-
-    public void setEventId(int eventId) {
-        this.eventId = eventId;
-    }
-
-    public LocalDateTime getStartTime() {
-        return startTime;
-    }
-
-    public void setStartTime(LocalDateTime startTime) {
-        this.startTime = startTime;
-    }
-
-    public LocalDateTime getEndTime() {
-        return endTime;
-    }
-
-    public void setEndTime(LocalDateTime endTime) {
-        this.endTime = endTime;
-    }
-
-    public CalendarItemType getType() {
-        return type;
-    }
-
-    public void setType(CalendarItemType type) {
-        this.type = type;
-    }
 }

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/model/CalendarItemType.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/model/CalendarItemType.java
@@ -1,0 +1,7 @@
+package com.ftn.iss.eventPlanner.model;
+
+public enum CalendarItemType {
+    CREATED_EVENT,
+    ACCEPTED_EVENT,
+    RESERVATION
+}


### PR DESCRIPTION
This pull request introduces a new feature to fetch calendar items associated with an account. It includes updates to the `AccountController` and `AccountService` classes, the creation of a new DTO (`GetCalendarItemDTO`) and an enum (`CalendarItemType`), and integration with the `ReservationService`. The changes ensure that users can retrieve their calendar items based on their roles and associated events or reservations.

### New Feature: Calendar Items Retrieval

* **Controller Update**: Added a new endpoint `/account/{accountId}/calendar` in `AccountController` to fetch calendar items for a specific account. The endpoint is secured with `@PreAuthorize` annotations to restrict access based on user roles. 
* **Service Logic**: Implemented the `getCalendar` method in `AccountService` to retrieve calendar items based on the account's role. It handles accepted events, events created by organizers, and reservations for providers. 

### Supporting Code Changes

* **DTO Creation**: Added `GetCalendarItemDTO` to encapsulate calendar item details, including title, event ID, start and end times, and type.
* **Enum Creation**: Introduced `CalendarItemType` to categorize calendar items as `CREATED_EVENT`, `ACCEPTED_EVENT`, or `RESERVATION`. 