### PR TITLE
Add Redirect Flow And Update Invitation Link To Dynamic IP

### DIFF
--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/config/WebSecurityConfig.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/config/WebSecurityConfig.java
@@ -97,14 +97,17 @@ public class WebSecurityConfig {
                         "api/comments*","api/images","api/images/*","api/offerings/*/comments",
                         "api/reservations/*",
                         "api/offerings/provider/*",
-                        "api/users/*")
+                        "api/events/accept-invite/**",
+                        "api/users/*",
+                        "api/events/process-invitation/**")
                 .requestMatchers(HttpMethod.POST,
                         "api/accounts/*/favourite-events",
                         "api/accounts/*/favourite-offerings",
                         "api/events/*/stats/participants",
                         "api/events/*/ratings",
                         "api/messages/**",
-                        "api/events/accept-invite/**")
+                        "api/events/accept-invite/**",
+                        "api/events/process-invitation/**")
                 .requestMatchers(HttpMethod.DELETE,
                         "api/accounts/*/favourite-events/*","api/accounts/*/favourite-offerings/*");
     }

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/config/WebSecurityConfig.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/config/WebSecurityConfig.java
@@ -99,7 +99,8 @@ public class WebSecurityConfig {
                         "api/offerings/provider/*",
                         "api/events/accept-invite/**",
                         "api/users/*",
-                        "api/events/process-invitation/**")
+                        "api/events/process-invitation/**",
+                        "api/events/accept-invite/**")
                 .requestMatchers(HttpMethod.POST,
                         "api/accounts/*/favourite-events",
                         "api/accounts/*/favourite-offerings",

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/services/EventService.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/services/EventService.java
@@ -451,6 +451,16 @@ public class EventService {
         for (String email : emails.getGuests()) {
             inviteGuest(eventId, email);
         }
+
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new NotFoundException("Event not found."));
+
+        EventStats stats = event.getStats();
+        if(stats.getParticipantsCount()>=event.getMaxParticipants()){
+            throw new IllegalArgumentException("Event is full");
+        }
+        stats.setParticipantsCount(event.getGuestList().size());
+        eventStatsRepository.save(stats);
     }
 
     @Transactional

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/services/EventService.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/services/EventService.java
@@ -15,6 +15,7 @@ import com.ftn.iss.eventPlanner.model.EventStats;
 import com.ftn.iss.eventPlanner.model.*;
 import com.ftn.iss.eventPlanner.model.specification.EventSpecification;
 import com.ftn.iss.eventPlanner.repositories.*;
+import com.ftn.iss.eventPlanner.util.NetworkUtils;
 import net.sf.jasperreports.engine.*;
 import net.sf.jasperreports.engine.data.JRBeanCollectionDataSource;
 import org.modelmapper.ModelMapper;
@@ -31,6 +32,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.webjars.NotFoundException;
 
 import java.io.InputStream;
+import java.net.SocketException;
 import java.time.LocalDate;
 import java.util.*;
 import java.util.Comparator;
@@ -66,11 +68,15 @@ public class EventService {
     @Autowired
     private BCryptPasswordEncoder passwordEncoder;
 
-    @Value("${app.frontend-base-url}") private String baseUrl;
+    @Value("${app.base-url}") private String baseUrl;
 
     private static final int TOKEN_EXPIRATION = 7;
+    private final String IP_BASE_URL = "http://" + NetworkUtils.getLocalIpAddress() + ":8080/api";
 
-    private static final String CONFIRMATION_URL = "/accept-invite?invitation-token=";
+    private static final String CONFIRMATION_URL = "/events/accept-invite/";
+
+    public EventService() throws SocketException {
+    }
 
     public List<GetEventDTO> findAll() {
         List<Event> events = eventRepository.findAll();
@@ -123,8 +129,7 @@ public class EventService {
                 .and(EventSpecification.maxParticipants(maxParticipants))
                 .and(EventSpecification.betweenDates(startDate, endDate))
                 .and(EventSpecification.minAverageRating(minRating))
-                .and(EventSpecification.hasName(name))
-                .and(EventSpecification.isOpen());
+                .and(EventSpecification.hasName(name));
 
         Page<Event> pagedEvents = eventRepository.findAll(specification, pageable);
 
@@ -488,7 +493,7 @@ public class EventService {
         token.setExpiresAt(LocalDateTime.now().plusDays(TOKEN_EXPIRATION));
         eventInviteTokenRepository.save(token);
 
-        String inviteLink = baseUrl + CONFIRMATION_URL + token.getToken();
+        String inviteLink = IP_BASE_URL + CONFIRMATION_URL + token.getToken();
 
         String message = "You're invited to the event: " + event.getName() +
                 "\n\n📅 Date: " + event.getDate() +

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/util/NetworkUtils.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/util/NetworkUtils.java
@@ -1,0 +1,14 @@
+package com.ftn.iss.eventPlanner.util;
+
+import java.net.*;
+
+public class NetworkUtils {
+    public static String getLocalIpAddress() throws SocketException {
+        try(final DatagramSocket socket = new DatagramSocket()) {
+            socket.connect(InetAddress.getByName("8.8.8.8"), 10002);
+            return socket.getLocalAddress().getHostAddress();
+        } catch (Exception e) {
+            return "localhost";
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces enhancements to the event invitation flow, including dynamic IP handling and redirect support for mobile and web clients.

* Added `NetworkUtils` utility to retrieve local IP address for use in backend links.
* Updated event invitation links to use local IP instead of hardcoded `localhost`.
* Introduced `/events/accept-invite/{token}` `GET` endpoint to redirect users to platform-specific clients:

  * Android: `m3.eventplanner://`
  * Web: `http://<ip>:4200`
* Added `/events/process-invitation` `POST` endpoint to complete invitation processing after login.
* Updated Spring Security configuration to permit access to new endpoints.
* Cleaned up redundant conditions in `EventService#getAllEvents`.