### PR TITLE
Fix Reservation Service And Add Notifications Unread Endpoint

### DIFF
--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/NotificationController.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/NotificationController.java
@@ -57,4 +57,12 @@ public class NotificationController {
         notificationService.toggleNotifications(accountId);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
+
+    @PreAuthorize("hasAnyAuthority('EVENT_ORGANIZER','PROVIDER','AUTHENTICATED_USER','ADMIN')")
+    @GetMapping("{accountId}/has-unread")
+    public ResponseEntity<Boolean> hasUnreadMessages(
+            @PathVariable Integer accountId) {
+        Boolean response = notificationService.hasUnreadMessages(accountId);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/ReservationController.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/ReservationController.java
@@ -89,14 +89,14 @@ public class ReservationController {
     }
 
     @PreAuthorize("hasAnyAuthority('PROVIDER')")
-    @PutMapping(value="/{reservationId}/accept", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PutMapping(value="/{reservationId}/accept", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Void> acceptReservation(@PathVariable("reservationId") int reservationId) throws Exception {
         reservationService.acceptReservation(reservationId);
         return ResponseEntity.noContent().build();
     }
 
     @PreAuthorize("hasAnyAuthority('PROVIDER')")
-    @PutMapping(value="/{reservationId}/reject", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PutMapping(value="/{reservationId}/reject", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Void> rejectReservation(@PathVariable("reservationId") int reservationId) throws Exception {
         reservationService.rejectReservation(reservationId);
         return ResponseEntity.noContent().build();

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/services/NotificationService.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/services/NotificationService.java
@@ -137,5 +137,15 @@ public class NotificationService {
         account.setNotificationsSilenced(!account.isNotificationsSilenced());
         accountRepository.save(account);
     }
+
+    public Boolean hasUnreadMessages(Integer accountId) {
+        Account account = accountRepository.findById(accountId)
+                .orElseThrow(() -> new NotFoundException("Account not found with ID: " + accountId));
+        Set<Notification> notifications = account.getNotifications();
+
+        return notifications.stream()
+                .anyMatch(notification -> !notification.isRead());
+    }
+
 }
 

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/services/ReservationService.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/services/ReservationService.java
@@ -44,6 +44,8 @@ public class ReservationService {
     private EmailService emailService;
     @Autowired
     private ScheduledNotificationService scheduledNotificationService;
+    @Autowired
+    private NotificationService notificationService;
 
 
     public List<GetReservationDTO> findAll(){
@@ -359,7 +361,7 @@ public class ReservationService {
         List<Reservation> reservations = reservationRepository.findAll();
 
         return reservations.stream()
-                .filter(reservation -> reservation.getService().getProvider().getId() == providerId)
+                .filter(reservation -> reservation.getService().getProvider().getAccount().getId() == providerId)
                 .filter(reservation -> reservation.getStatus() == Status.PENDING)
                 .map(this::mapToGetReservationDTO)
                 .toList();
@@ -380,6 +382,8 @@ public class ReservationService {
                 .orElseThrow(() -> new NotFoundException("Reservation with ID " + reservationId + " not found"));
         reservation.setStatus(Status.ACCEPTED);
         reservationRepository.save(reservation);
+        notificationService.sendNotification(reservation.getEvent().getOrganizer().getAccount().getId(),"Reservation Accepted",
+                "Your reservation for " + reservation.getEvent().getName() + " has been accepted.");
     }
 
     public void rejectReservation(int reservationId) {
@@ -387,5 +391,7 @@ public class ReservationService {
                 .orElseThrow(() -> new NotFoundException("Reservation with ID " + reservationId + " not found"));
         reservation.setStatus(Status.DENIED);
         reservationRepository.save(reservation);
+        notificationService.sendNotification(reservation.getEvent().getOrganizer().getAccount().getId(),"Reservation Denied",
+                "Your reservation for " + reservation.getEvent().getName() + " has been denied.");
     }
 }


### PR DESCRIPTION
This update introduces several backend improvements related to reservation and notification handling:

* Added a new endpoint `/notifications/{accountId}/has-unread` to check if a user has any unread notifications upon login.
* Updated the reservation approval and rejection endpoints by removing the unnecessary `consumes` attribute from the `@PutMapping` annotations.
* Fixed the logic in `ReservationService.findPendingReservations` to correctly filter reservations based on provider account ID.
* Extended `ReservationService` to send real-time notifications when a reservation is accepted or rejected.