### PR TITLE
Add provider filter to get offerings

### DIFF
--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/OfferingController.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/OfferingController.java
@@ -87,12 +87,13 @@ public class OfferingController {
             @RequestParam(required = false) Double minRating,
             @RequestParam(required = false) Boolean isAvailable,
             @RequestParam(required = false) String sortBy,
-            @RequestParam(required = false) String sortDirection
+            @RequestParam(required = false) String sortDirection,
+            @RequestParam(required = false) Integer providerId
     ){
         try{
             PagedResponse<GetOfferingDTO> offerings = offeringService.getAllOfferings(
                     pageable, isServiceFilter, name, categoryId, location, startPrice,
-                    endPrice, minDiscount, serviceDuration, minRating, isAvailable, sortBy, sortDirection);
+                    endPrice, minDiscount, serviceDuration, minRating, isAvailable, sortBy, sortDirection, providerId);
 
 
             return ResponseEntity.ok(offerings);

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/model/specification/ProductSpecification.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/model/specification/ProductSpecification.java
@@ -83,4 +83,10 @@ public class ProductSpecification {
         return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("currentDetails").get("isVisible"), true);
     }
 
+    public static Specification<Product> hasProviderId(Integer providerId) {
+        return (root, query, criteriaBuilder) ->
+                providerId != null
+                        ? criteriaBuilder.equal(root.get("provider").get("id"), providerId)
+                        : criteriaBuilder.conjunction();
+    }
 }

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/model/specification/ServiceSpecification.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/model/specification/ServiceSpecification.java
@@ -102,4 +102,11 @@ public class ServiceSpecification {
     public static Specification<Service> isVisible() {
         return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("currentDetails").get("isVisible"), true);
     }
+
+    public static Specification<Service> hasProviderId(Integer providerId) {
+        return (root, query, criteriaBuilder) ->
+                providerId != null
+                        ? criteriaBuilder.equal(root.get("provider").get("id"), providerId)
+                        : criteriaBuilder.conjunction();
+    }
 }

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/services/OfferingService.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/services/OfferingService.java
@@ -109,7 +109,8 @@ public class OfferingService {
             Double minRating,
             Boolean searchByAvailability,
             String sortBy,
-            String sortDirection
+            String sortDirection,
+            Integer providerId
     ) {
         if (sortBy != null && !"none".equalsIgnoreCase(sortBy)) {
             String sortField = switch (sortBy.toLowerCase()) {
@@ -140,7 +141,8 @@ public class OfferingService {
                     .and(ServiceSpecification.minRating(minRating))
                     .and(ServiceSpecification.hasServiceDuration(serviceDuration))
                     .and(ServiceSpecification.isAvailable(searchByAvailability))
-                    .and(ServiceSpecification.isVisible());
+                    .and(ServiceSpecification.isVisible())
+                    .and(ServiceSpecification.hasProviderId(providerId));
 
             pagedOfferings = serviceRepository.findAll(serviceSpecification, pageable);
 
@@ -152,14 +154,15 @@ public class OfferingService {
                     .and(ProductSpecification.minDiscount(minDiscount))
                     .and(ProductSpecification.minRating(minRating))
                     .and(ProductSpecification.isAvailable(searchByAvailability))
-                    .and(ProductSpecification.isVisible());
+                    .and(ProductSpecification.isVisible())
+                    .and(ProductSpecification.hasProviderId(providerId));
 
             pagedOfferings = productRepository.findAll(productSpecification, pageable);
 
         } else {
-            Specification<Service> serviceSpecification = Specification.where(ServiceSpecification.isVisible());
+            Specification<Service> serviceSpecification = Specification.where(ServiceSpecification.isVisible().and(ServiceSpecification.hasProviderId(providerId)));
 
-            Specification<Product> productSpecification = Specification.where(ProductSpecification.isVisible());
+            Specification<Product> productSpecification = Specification.where(ProductSpecification.isVisible().and(ProductSpecification.hasProviderId(providerId)));
 
             List<Service> services = serviceRepository.findAll(serviceSpecification);
             List<Product> products = productRepository.findAll(productSpecification);


### PR DESCRIPTION
This pull request introduces a new filtering capability based on `providerId` for offerings in the `eventPlanner` application. The changes include updates to controller methods, service methods, and specifications to support this additional filter.

### Controller Updates:
*  Added a new optional request parameter `providerId` to the `getOfferings` method, enabling filtering based on the provider's ID. The parameter is passed to the service layer.

### Specification Enhancements:
* Introduced a new specification method `hasProviderId` to filter products by `providerId`. If `providerId` is null, it returns a conjunction to avoid filtering.
* Added a similar `hasProviderId` method for filtering services by `providerId`.

### Service Layer Updates:
* Extended the `getAllOfferings` method to accept `providerId` as a parameter and incorporated the new `hasProviderId` specifications for both services and products. This ensures offerings can be filtered by their associated provider.