### PR TITLE
Implement guestlist report

### DIFF
--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/EventController.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/EventController.java
@@ -176,6 +176,15 @@ public class EventController {
                 .body(pdfReport);
     }
 
+    @PreAuthorize("hasAnyAuthority('EVENT_ORGANIZER')")
+    @GetMapping(value="/{eventId}/reports/guestlist", produces = MediaType.APPLICATION_PDF_VALUE)
+    public ResponseEntity<byte[]> getGuestlistReport(@PathVariable int eventId) throws JRException {
+        byte[] pdfReport= eventService.generateGuestlistReport(eventId);
+        return ResponseEntity.ok()
+                .header("Content-Disposition", "inline; filename=event_report.pdf")
+                .body(pdfReport);
+    }
+
     @PreAuthorize("hasAnyAuthority('EVENT_ORGANIZER','ADMIN')")
     @GetMapping(value="/{eventId}/stats", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<GetEventStatsDTO> getEventStats(@PathVariable int eventId) {

--- a/eventPlanner/src/main/resources/template/guestlist_report.jrxml
+++ b/eventPlanner/src/main/resources/template/guestlist_report.jrxml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports
+              http://jasperreports.sourceforge.net/xsd/jasperreport.xsd"
+              name="guestlist_report" pageWidth="595" pageHeight="842" columnWidth="555"
+              leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20"
+              uuid="b395bc9c-fc5a-4ab1-bb2f-49b457b2f6c1">
+
+    <parameter name="GuestSubreport" class="net.sf.jasperreports.engine.JasperReport"/>
+    <parameter name="GuestListDataSource" class="net.sf.jasperreports.engine.JRDataSource"/>
+
+    <field name="eventName" class="java.lang.String"/>
+
+    <title>
+        <band height="50">
+            <textField>
+                <reportElement x="0" y="10" width="555" height="30"/>
+                <textElement textAlignment="Center">
+                    <font size="18" isBold="true"/>
+                </textElement>
+                <textFieldExpression><![CDATA["Event: " + $F{eventName}]]></textFieldExpression>
+            </textField>
+        </band>
+    </title>
+
+    <summary>
+        <band height="300">
+            <subreport>
+                <reportElement x="0" y="10" width="555" height="280"/>
+                <subreportParameter name="REPORT_DATA_SOURCE">
+                    <subreportParameterExpression><![CDATA[$P{GuestListDataSource}]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportExpression><![CDATA[$P{GuestSubreport}]]></subreportExpression>
+            </subreport>
+        </band>
+    </summary>
+
+</jasperReport>

--- a/eventPlanner/src/main/resources/template/guestlist_subreport.jrxml
+++ b/eventPlanner/src/main/resources/template/guestlist_subreport.jrxml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports
+              http://jasperreports.sourceforge.net/xsd/jasperreport.xsd"
+              name="guestlist_subreport" pageWidth="555" pageHeight="100" columnWidth="555"
+              leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0"
+              uuid="df1d91c2-dad5-4b73-a697-d2f38fc709b3">
+
+    <field name="guestName" class="java.lang.String"/>
+
+    <detail>
+        <band height="20">
+            <textField>
+                <reportElement x="0" y="0" width="555" height="20"/>
+                <textElement>
+                    <font size="12"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$F{guestName}]]></textFieldExpression>
+            </textField>
+        </band>
+    </detail>
+
+</jasperReport>


### PR DESCRIPTION
This pull request introduces functionality for generating and downloading guest list reports in PDF format for events. The changes include adding a new endpoint in the `EventController`, implementing the report generation logic in `EventService`, and creating JasperReports templates for the main report and its subreport.

### New Guest List Report Feature:

* **Controller Update**: Added a new endpoint `getGuestlistReport` in `EventController` to allow event organizers to download guest list reports in PDF format. The endpoint is secured with `@PreAuthorize("hasAnyAuthority('EVENT_ORGANIZER')")`. 

* **Service Logic**: Implemented the `generateGuestlistReport` method in `EventService`, which compiles JasperReports templates, populates them with event and guest list data, and generates the PDF report. 

### JasperReports Templates:

* **Main Report Template**: Created `guestlist_report.jrxml`, which defines the structure of the guest list report, including the event name and a subreport for the guest list. 

* **Subreport Template**: Created `guestlist_subreport.jrxml`, which defines the structure for displaying individual guest names in the report.