### PR TITLE
Refactor Homepage Logic To Exclude Deleted Events, Deleted And Pending Offerings

### DIFF
--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/OfferingController.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/OfferingController.java
@@ -88,12 +88,13 @@ public class OfferingController {
             @RequestParam(required = false) Boolean isAvailable,
             @RequestParam(required = false) String sortBy,
             @RequestParam(required = false) String sortDirection,
+            @RequestParam(required = false) Integer accountId,
             @RequestParam(required = false) Integer providerId
     ){
         try{
             PagedResponse<GetOfferingDTO> offerings = offeringService.getAllOfferings(
                     pageable, isServiceFilter, name, categoryId, location, startPrice,
-                    endPrice, minDiscount, serviceDuration, minRating, isAvailable, sortBy, sortDirection, providerId);
+                    endPrice, minDiscount, serviceDuration, minRating, isAvailable, sortBy, sortDirection, accountId, providerId);
 
 
             return ResponseEntity.ok(offerings);

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/model/specification/EventSpecification.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/model/specification/EventSpecification.java
@@ -58,4 +58,8 @@ public class EventSpecification {
     public static Specification<Event> isOpen() {
         return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("isOpen"), true);
     }
+
+    public static Specification<Event> isNotDeleted() {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("isDeleted"), false);
+    }
 }

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/model/specification/ProductSpecification.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/model/specification/ProductSpecification.java
@@ -2,6 +2,7 @@ package com.ftn.iss.eventPlanner.model.specification;
 
 import com.ftn.iss.eventPlanner.model.Comment;
 import com.ftn.iss.eventPlanner.model.Product;
+import com.ftn.iss.eventPlanner.model.Service;
 import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Root;
@@ -25,10 +26,10 @@ public class ProductSpecification {
                         : criteriaBuilder.conjunction();
     }
 
-    public static Specification<Product> hasLocation(String location) {
+    public static Specification<Product> hasLocation(String location, Integer providerId) {
         return (root, query, criteriaBuilder) ->
-                location != null && !location.isEmpty()
-                        ? criteriaBuilder.like(criteriaBuilder.lower(root.get("provider").get("location").get("city")), "%" + location.toLowerCase() + "%")
+                providerId == null && location != null && !location.isEmpty()
+                        ? criteriaBuilder.like(criteriaBuilder.lower(root.get("provider").get("company").get("location").get("city")), "%" + location.toLowerCase() + "%")
                         : criteriaBuilder.conjunction();
     }
 
@@ -81,6 +82,14 @@ public class ProductSpecification {
 
     public static Specification<Product> isVisible() {
         return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("currentDetails").get("isVisible"), true);
+    }
+
+    public static Specification<Product> isNotDeleted() {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("isDeleted"), false);
+    }
+
+    public static Specification<Product> isNotPending() {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("pending"), false);
     }
 
     public static Specification<Product> hasProviderId(Integer providerId) {

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/model/specification/ServiceSpecification.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/model/specification/ServiceSpecification.java
@@ -26,10 +26,10 @@ public class ServiceSpecification {
                         : criteriaBuilder.conjunction();
     }
 
-    public static Specification<Service> hasLocation(String location) {
+    public static Specification<Service> hasLocation(String location, Integer providerId) {
         return (root, query, criteriaBuilder) ->
-                location != null && !location.isEmpty()
-                        ? criteriaBuilder.like(criteriaBuilder.lower(root.get("provider").get("location").get("city")), "%" + location.toLowerCase() + "%")
+                providerId == null && location != null && !location.isEmpty()
+                        ? criteriaBuilder.like(criteriaBuilder.lower(root.get("provider").get("company").get("location").get("city")), "%" + location.toLowerCase() + "%")
                         : criteriaBuilder.conjunction();
     }
 
@@ -101,6 +101,14 @@ public class ServiceSpecification {
 
     public static Specification<Service> isVisible() {
         return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("currentDetails").get("isVisible"), true);
+    }
+
+    public static Specification<Service> isNotDeleted() {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("isDeleted"), false);
+    }
+
+    public static Specification<Service> isNotPending() {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("pending"), false);
     }
 
     public static Specification<Service> hasProviderId(Integer providerId) {

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/services/EventService.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/services/EventService.java
@@ -129,7 +129,9 @@ public class EventService {
                 .and(EventSpecification.maxParticipants(maxParticipants))
                 .and(EventSpecification.betweenDates(startDate, endDate))
                 .and(EventSpecification.minAverageRating(minRating))
-                .and(EventSpecification.hasName(name));
+                .and(EventSpecification.hasName(name))
+                .and(EventSpecification.isOpen())
+                .and(EventSpecification.isNotDeleted());
 
         Page<Event> pagedEvents = eventRepository.findAll(specification, pageable);
 
@@ -144,7 +146,7 @@ public class EventService {
         List<GetEventDTO> eventDTOs = new ArrayList<>();
         if (accountId != null) {
             eventDTOs = events.stream()
-                    .filter(event -> event.getOrganizer().getAccount().getId() == accountId)
+                    .filter(event -> event.getOrganizer().getAccount().getId() == accountId && !event.isDeleted())
                     .map(this::mapToGetEventDTO)
                     .collect(Collectors.toList());
         }
@@ -160,7 +162,8 @@ public class EventService {
             if (userLocation != null) {
                 events = events.stream()
                         .filter(event -> event.getLocation() != null &&
-                                event.getLocation().getCity().equalsIgnoreCase(userLocation.getCity()))
+                                event.getLocation().getCity().equalsIgnoreCase(userLocation.getCity()) &&
+                                !event.isDeleted())
                         .collect(Collectors.toList());
             }
         }

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/services/OfferingService.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/services/OfferingService.java
@@ -10,10 +10,7 @@ import com.ftn.iss.eventPlanner.dto.user.GetProviderDTO;
 import com.ftn.iss.eventPlanner.model.*;
 import com.ftn.iss.eventPlanner.model.specification.ProductSpecification;
 import com.ftn.iss.eventPlanner.model.specification.ServiceSpecification;
-import com.ftn.iss.eventPlanner.repositories.OfferingCategoryRepository;
-import com.ftn.iss.eventPlanner.repositories.OfferingRepository;
-import com.ftn.iss.eventPlanner.repositories.ProductRepository;
-import com.ftn.iss.eventPlanner.repositories.ServiceRepository;
+import com.ftn.iss.eventPlanner.repositories.*;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.*;
@@ -29,8 +26,6 @@ public class OfferingService {
     @Autowired
     private OfferingRepository offeringRepository;
     @Autowired
-    private OfferingCategoryService offeringCategoryService;
-    @Autowired
     private  NotificationService notificationService;
     @Autowired
     private ServiceRepository serviceRepository;
@@ -38,6 +33,8 @@ public class OfferingService {
     private ProductRepository productRepository;
     @Autowired
     private OfferingCategoryRepository offeringCategoryRepository;
+    @Autowired
+    private AccountRepository accountRepository;
 
     private ModelMapper modelMapper = new ModelMapper();
 
@@ -66,7 +63,7 @@ public class OfferingService {
         if (isServiceFilter == Boolean.TRUE) {
             Specification<Service> serviceSpecification = Specification.where(ServiceSpecification.hasName(name))
                     .and(ServiceSpecification.hasCategoryId(categoryId))
-                    .and(ServiceSpecification.hasLocation(location))
+                    .and(ServiceSpecification.hasLocation(location, null))
                     .and(ServiceSpecification.betweenPrices(minPrice, maxPrice))
                     .and(ServiceSpecification.minDiscount(minDiscount))
                     .and(ServiceSpecification.minRating(minRating))
@@ -79,7 +76,7 @@ public class OfferingService {
         } else if (isServiceFilter == Boolean.FALSE) {
             Specification<Product> productSpecification = Specification.where(ProductSpecification.hasName(name))
                     .and(ProductSpecification.hasCategoryId(categoryId))
-                    .and(ProductSpecification.hasLocation(location))
+                    .and(ProductSpecification.hasLocation(location, null))
                     .and(ProductSpecification.betweenPrices(minPrice, maxPrice))
                     .and(ProductSpecification.minDiscount(minDiscount))
                     .and(ProductSpecification.minRating(minRating))
@@ -110,14 +107,23 @@ public class OfferingService {
             Boolean searchByAvailability,
             String sortBy,
             String sortDirection,
+            Integer accountId,
             Integer providerId
     ) {
+        if (accountId != null && (location == null || location.isEmpty())) {
+            Account account = accountRepository.findById(accountId).orElse(null);
+            Location userLocation = account.getUser().getLocation();
+            if (userLocation != null) {
+                location = userLocation.getCity();
+            }
+        }
+
         if (sortBy != null && !"none".equalsIgnoreCase(sortBy)) {
             String sortField = switch (sortBy.toLowerCase()) {
                 case "price" -> "currentDetails.price";
                 case "averageRating" -> null; // Dynamically sorted
                 case "name" -> "currentDetails.name";
-                case "location.city" -> "provider.location.city";
+                case "location.city" -> "provider.company.location.city";
                 default -> null;
             };
 
@@ -135,34 +141,56 @@ public class OfferingService {
         if (isServiceFilter == Boolean.TRUE) {
             Specification<Service> serviceSpecification = Specification.where(ServiceSpecification.hasName(name))
                     .and(ServiceSpecification.hasCategoryId(categoryId))
-                    .and(ServiceSpecification.hasLocation(location))
+                    .and(ServiceSpecification.hasLocation(location, providerId))
                     .and(ServiceSpecification.betweenPrices(minPrice, maxPrice))
                     .and(ServiceSpecification.minDiscount(minDiscount))
                     .and(ServiceSpecification.minRating(minRating))
                     .and(ServiceSpecification.hasServiceDuration(serviceDuration))
                     .and(ServiceSpecification.isAvailable(searchByAvailability))
-                    .and(ServiceSpecification.isVisible())
-                    .and(ServiceSpecification.hasProviderId(providerId));
+                    .and(ServiceSpecification.hasProviderId(providerId))
+                    .and(ServiceSpecification.isNotDeleted());
+
+            if(providerId == null){
+                serviceSpecification = serviceSpecification.and(ServiceSpecification.isVisible())
+                        .and(ServiceSpecification.isNotPending());
+            }
 
             pagedOfferings = serviceRepository.findAll(serviceSpecification, pageable);
 
         } else if (isServiceFilter == Boolean.FALSE) {
             Specification<Product> productSpecification = Specification.where(ProductSpecification.hasName(name))
                     .and(ProductSpecification.hasCategoryId(categoryId))
-                    .and(ProductSpecification.hasLocation(location))
+                    .and(ProductSpecification.hasLocation(location, providerId))
                     .and(ProductSpecification.betweenPrices(minPrice, maxPrice))
                     .and(ProductSpecification.minDiscount(minDiscount))
                     .and(ProductSpecification.minRating(minRating))
                     .and(ProductSpecification.isAvailable(searchByAvailability))
-                    .and(ProductSpecification.isVisible())
-                    .and(ProductSpecification.hasProviderId(providerId));
+                    .and(ProductSpecification.hasProviderId(providerId))
+                    .and(ProductSpecification.isNotDeleted());
+
+            if(providerId == null){
+                productSpecification = productSpecification.and(ProductSpecification.isVisible())
+                        .and(ProductSpecification.isNotPending());
+            }
 
             pagedOfferings = productRepository.findAll(productSpecification, pageable);
 
         } else {
-            Specification<Service> serviceSpecification = Specification.where(ServiceSpecification.isVisible().and(ServiceSpecification.hasProviderId(providerId)));
+            Specification<Service> serviceSpecification = Specification.where(ServiceSpecification.hasProviderId(providerId))
+                    .and(ServiceSpecification.isNotDeleted())
+                    .and(ServiceSpecification.hasLocation(location, providerId));
 
-            Specification<Product> productSpecification = Specification.where(ProductSpecification.isVisible().and(ProductSpecification.hasProviderId(providerId)));
+            Specification<Product> productSpecification = Specification.where(ProductSpecification.hasProviderId(providerId))
+                    .and(ProductSpecification.isNotDeleted())
+                    .and(ProductSpecification.hasLocation(location, providerId));
+
+            if(providerId == null){
+                serviceSpecification = serviceSpecification.and(ServiceSpecification.isVisible())
+                        .and(ServiceSpecification.isNotPending());
+
+                productSpecification = productSpecification.and(ProductSpecification.isVisible())
+                        .and(ProductSpecification.isNotPending());
+            }
 
             List<Service> services = serviceRepository.findAll(serviceSpecification);
             List<Product> products = productRepository.findAll(productSpecification);
@@ -204,9 +232,11 @@ public class OfferingService {
         return offerings.stream()
                 .filter(offering -> {
                     if (offering instanceof Product p) {
-                        return p.getCurrentDetails().isVisible();
+                        return p.getCurrentDetails().isVisible()
+                                && !p.isDeleted() && !p.isPending();
                     } else if (offering instanceof Service s) {
-                        return s.getCurrentDetails().isVisible();
+                        return s.getCurrentDetails().isVisible()
+                                && !s.isDeleted() && !s.isPending();
                     }
                     return false;
                 })
@@ -215,7 +245,6 @@ public class OfferingService {
                 .limit(5)
                 .map(this::mapToGetOfferingDTO)
                 .collect(Collectors.toList());
-
     }
 
     @Transactional(readOnly = true)

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/services/OfferingService.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/services/OfferingService.java
@@ -112,9 +112,11 @@ public class OfferingService {
     ) {
         if (accountId != null && (location == null || location.isEmpty())) {
             Account account = accountRepository.findById(accountId).orElse(null);
-            Location userLocation = account.getUser().getLocation();
-            if (userLocation != null) {
-                location = userLocation.getCity();
+            if (account != null && account.getUser() != null){
+                Location userLocation = account.getUser().getLocation();
+                if (userLocation != null) {
+                    location = userLocation.getCity();
+                }
             }
         }
 


### PR DESCRIPTION
In this pull request I've made requested adjustments for the homepage logic:

- Deleted events do not get fetched (change in the EventSpecification)
- Deleted and pending offerings do not get fetched for anyone on homepage
- Pending offerings get fetched only when providerId is sent as a parameter
- User location gets added as a parameter to get all offerings
- User location gets ignored if providerId is provided