### PR TITLE
Synchronize Comment Management With Offering Associations And Improve Comment Endpoints

### DIFF
--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/OfferingController.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/OfferingController.java
@@ -133,14 +133,14 @@ public class OfferingController {
     }
 
     @PreAuthorize("hasAnyAuthority('ADMIN')")
-    @DeleteMapping(value = "/comments/{commentId}")
-    public ResponseEntity<?> deleteComment(@PathVariable int commentId) throws Exception {
+    @PutMapping (value = "/comments/{commentId}/reject",produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> rejectComment(@PathVariable int commentId) throws Exception {
         commentService.delete(commentId);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
     @PreAuthorize("hasAnyAuthority('ADMIN')")
-    @GetMapping(value="/comments/{commentId}/approve")
+    @PutMapping(value="/comments/{commentId}/approve", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<?> approveComment(@PathVariable int commentId) throws Exception {
         commentService.approve(commentId);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/OfferingController.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/OfferingController.java
@@ -132,10 +132,27 @@ public class OfferingController {
         return new ResponseEntity<UpdatedCommentDTO>(updatedComment, HttpStatus.OK);
     }
 
-    @DeleteMapping(value = "/{offeringId}/comments/{commentId}")
-    public ResponseEntity<?> deleteComment(@PathVariable int offeringId, @PathVariable int commentId) throws Exception {
+    @PreAuthorize("hasAnyAuthority('ADMIN')")
+    @DeleteMapping(value = "/comments/{commentId}")
+    public ResponseEntity<?> deleteComment(@PathVariable int commentId) throws Exception {
+        commentService.delete(commentId);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
+
+    @PreAuthorize("hasAnyAuthority('ADMIN')")
+    @GetMapping(value="/comments/{commentId}/approve")
+    public ResponseEntity<?> approveComment(@PathVariable int commentId) throws Exception {
+        commentService.approve(commentId);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+    @PreAuthorize("hasAnyAuthority('ADMIN')")
+    @GetMapping(value="/comments/pending")
+    public ResponseEntity<Collection<GetCommentDTO>> getPendingComments(){
+        Collection<GetCommentDTO> comments = commentService.getPendingComments();
+        return new ResponseEntity<>(comments, HttpStatus.OK);
+    }
+
 
     @GetMapping(value = "/highest-prices")
     public ResponseEntity<?> getHighestPrice(@RequestParam(required = false) Boolean isService) {

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/repositories/OfferingRepository.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/repositories/OfferingRepository.java
@@ -3,9 +3,15 @@ package com.ftn.iss.eventPlanner.repositories;
 import com.ftn.iss.eventPlanner.model.Offering;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface OfferingRepository extends JpaRepository<Offering,Integer>, JpaSpecificationExecutor<Offering> {
     List<Offering> findByProvider_Id(int providerId);
+
+    @Query("SELECT o FROM Offering o JOIN o.comments c WHERE c.id = :commentId")
+    Optional<Offering> findByCommentId(@Param("commentId") int commentId);
 }

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/services/OfferingService.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/services/OfferingService.java
@@ -235,7 +235,7 @@ public class OfferingService {
 
         if (offering.isPresent()) {
             return offering.get().getComments().stream()
-                    .filter(comment -> comment.getStatus() != Status.PENDING)
+                    .filter(comment -> comment.getStatus() == Status.ACCEPTED)
                     .map(this::mapToGetCommentDTO)
                     .collect(Collectors.toList());
         } else {

--- a/eventPlanner/src/main/resources/data.sql
+++ b/eventPlanner/src/main/resources/data.sql
@@ -75,13 +75,7 @@ INSERT INTO comment (content, status, commenter_id, rating) VALUES
                                                                 ('There was a delay in service.', 0, 2, 3),
                                                                 ('Everything was perfect.', 1, 1, 5),
                                                                 ('The food was too spicy.', 1, 3, 2),
-                                                                ('The lighting was great.', 1, 2, 4),
-                                                                ('The stage design was creative.', 1, 4, 5),
-                                                                ('The event exceeded my expectations.', 1, 1, 5),
-                                                                ('The parking area was small.', 0, 3, 3),
-                                                                ('Good value for money.', 1, 4, 4),
-                                                                ('The event was too crowded.', 1, 2, 2),
-                                                                ('I had a wonderful time.', 1, 1, 5);
+                                                                ('The lighting was great.', 1, 2, 4);
 INSERT INTO message (content, timestamp, sender_id, receiver_id, is_read) VALUES
                                                                                   ( 'Hello, when is the event?', '2023-12-05 09:00:00', 1, 2, FALSE),
                                                                                   ( 'Can you provide more details?', '2023-12-06 10:00:00', 2, 1, TRUE);
@@ -173,8 +167,7 @@ INSERT INTO offerings_comments (offering_id, comments_id) VALUES
                                                              (16, 25),
                                                              (17, 26),
                                                              (18, 27),
-                                                             (19, 28),
-                                                             (20, 29);
+                                                             (19, 28);
 INSERT INTO account_notifications (account_id, notifications_id) VALUES
                                                                      (2, 1),
                                                                      (2, 2),


### PR DESCRIPTION
Updated OfferingController to secure and improve comment-related endpoints including delete, approve, and retrieval of pending comments.

Added a method in OfferingRepository to find an Offering by associated comment ID to maintain integrity between comments and offerings.

Enhanced CommentService with implementations to:

* Retrieve all pending comments filtered by status.
* Approve a comment by updating its status and ensuring it is linked to an offering.
* Delete (deny) a comment by setting its status, removing it from the offering’s comment list, and persisting the changes.

Refined OfferingService’s comment retrieval to filter only accepted comments and remove redundant filtering logic.

Cleaned up SQL seed data to fix duplicated insertions and ensure consistency between comments and comment-offering relationships.
