### PR TITLE
Refactor: Pass full offering to ChangeCategoryDialogComponent instead of category 

### DIFF
--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/OfferingController.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/OfferingController.java
@@ -3,6 +3,7 @@ package com.ftn.iss.eventPlanner.controller;
 import com.ftn.iss.eventPlanner.dto.*;
 import com.ftn.iss.eventPlanner.dto.comment.*;
 import com.ftn.iss.eventPlanner.dto.offering.GetOfferingDTO;
+import com.ftn.iss.eventPlanner.dto.offeringcategory.ChangeCategoryDTO;
 import com.ftn.iss.eventPlanner.services.CommentService;
 import com.ftn.iss.eventPlanner.services.OfferingService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -163,14 +164,17 @@ public class OfferingController {
     }
     @PutMapping("/{offeringId}/category")
     @PreAuthorize("hasAnyAuthority('ADMIN')")
-    public ResponseEntity<?> changeOfferingCategory(@PathVariable int offeringId, @RequestBody int categoryId) {
+    public ResponseEntity<?> changeOfferingCategory(
+            @PathVariable int offeringId,
+            @RequestBody ChangeCategoryDTO request) {
         try {
-            offeringService.changeCategory(offeringId, categoryId);
+            offeringService.changeCategory(offeringId, request.getNewCategoryId());
             return ResponseEntity.ok().build();
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Error: " + e.getMessage());
         }
     }
+
     @GetMapping(value="/all-non-paged", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Collection<GetOfferingDTO>> getOfferings() {
         try {

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/dto/offeringcategory/ChangeCategoryDTO.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/dto/offeringcategory/ChangeCategoryDTO.java
@@ -1,0 +1,13 @@
+package com.ftn.iss.eventPlanner.dto.offeringcategory;
+
+public class ChangeCategoryDTO {
+    public int newCategoryId;
+
+    public int getNewCategoryId() {
+        return newCategoryId;
+    }
+
+    public void setNewCategoryId(int newCategoryId) {
+        this.newCategoryId = newCategoryId;
+    }
+}

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/services/OfferingCategoryService.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/services/OfferingCategoryService.java
@@ -29,6 +29,7 @@ public class OfferingCategoryService {
         List<OfferingCategory> offeringCategorys = offeringCategoryRepository.findAll();
         return offeringCategorys.stream()
                 .map(offeringCategory -> modelMapper.map(offeringCategory, GetOfferingCategoryDTO.class))
+                .filter(offeringCategory->!offeringCategory.isDeleted())
                 .collect(Collectors.toList());
     }
 
@@ -50,11 +51,15 @@ public class OfferingCategoryService {
         OfferingCategory offeringCategory = offeringCategoryRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Category with ID " + id + " not found"));
 
-        modelMapper.map(updateOfferingCategoryDTO, offeringCategory);
+        offeringCategory.setName(updateOfferingCategoryDTO.getName());
+        offeringCategory.setDescription(updateOfferingCategoryDTO.getDescription());
+
         offeringCategory = offeringCategoryRepository.save(offeringCategory);
+
         approve(id, "Your category has been updated and approved");
         return modelMapper.map(offeringCategory, UpdatedOfferingCategoryDTO.class);
     }
+
 
     public boolean delete(int id) {
         OfferingCategory offeringCategory = offeringCategoryRepository.findById(id)

--- a/eventPlanner/src/main/resources/data.sql
+++ b/eventPlanner/src/main/resources/data.sql
@@ -22,7 +22,7 @@ UPDATE account SET user_id = 1 WHERE id = 3;
 
 INSERT INTO offering_category (name, description, is_deleted, pending, creator_id) VALUES
                                                                                ('Electronics', 'Category for electronic items.', FALSE, FALSE, 2),
-                                                                               ( 'Home Services', 'Category for home-related services.', FALSE, TRUE, 2),
+                                                                               ( 'Home Services', 'Category for home-related services.', FALSE, FALSE, 2),
                                                                                 ( 'Nova kategorija', 'Category for home-related services.', FALSE, TRUE, 3);
 
 INSERT INTO event_type ( name, description, is_active) VALUES


### PR DESCRIPTION
This pull request introduces support for changing the category of an offering via a dedicated DTO (`ChangeCategoryDTO`). Additionally, it includes filtering of deleted categories in `OfferingCategoryService` and minor refactoring for consistency.
Pass full offering to ChangeCategoryDialogComponent instead of category 

##  Controller Update
- `@PutMapping("/{offeringId}/category")` in `OfferingController` now accepts a JSON body of type `ChangeCategoryDTO` instead of a raw integer.
- This allows better validation, extensibility, and alignment with RESTful best practices.
