### PR TITLE
Block/Unblock Functionality + Homepage Logic Improvements

### DIFF
--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/AccountController.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/AccountController.java
@@ -5,6 +5,7 @@ import com.ftn.iss.eventPlanner.dto.calendaritem.GetCalendarItemDTO;
 import com.ftn.iss.eventPlanner.dto.event.AddFavouriteEventDTO;
 import com.ftn.iss.eventPlanner.dto.event.GetEventDTO;
 import com.ftn.iss.eventPlanner.dto.offering.GetOfferingDTO;
+import com.ftn.iss.eventPlanner.dto.user.BlockStatusDTO;
 import com.ftn.iss.eventPlanner.services.AccountService;
 import com.ftn.iss.eventPlanner.services.NotificationService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -75,5 +76,26 @@ public class AccountController {
     public ResponseEntity<Collection<GetCalendarItemDTO>> getCalendar(@PathVariable int accountId) {
         Collection<GetCalendarItemDTO> calendar = accountService.getCalendar(accountId);
         return ResponseEntity.ok(calendar);
+    }
+
+    @PreAuthorize("hasAnyAuthority('EVENT_ORGANIZER','PROVIDER', 'ADMIN', 'AUTHENTICATED_USER')")
+    @GetMapping(value="/{loggedInId}/blocked-accounts/{accountToBlockId}", produces = MediaType.APPLICATION_JSON_VALUE )
+    public ResponseEntity<BlockStatusDTO> isAccountBlocked(@PathVariable int loggedInId, @PathVariable int accountToBlockId) {
+        BlockStatusDTO blockStatusDTO = accountService.isAccountBlocked(loggedInId, accountToBlockId);
+        return ResponseEntity.ok(blockStatusDTO);
+    }
+
+    @PreAuthorize("hasAnyAuthority('EVENT_ORGANIZER','PROVIDER', 'ADMIN', 'AUTHENTICATED_USER')")
+    @PostMapping(value="/{loggedInId}/block/{accountToBlockId}")
+    public ResponseEntity<?> blockAccount(@PathVariable int loggedInId, @PathVariable int accountToBlockId) {
+        accountService.blockAccount(loggedInId, accountToBlockId);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+    @PreAuthorize("hasAnyAuthority('EVENT_ORGANIZER','PROVIDER','ADMIN','AUTHENTICATED_USER')")
+    @DeleteMapping("/{loggedInId}/unblock/{accountToUnblockId}")
+    public ResponseEntity<Void> unblockAccount(@PathVariable int loggedInId, @PathVariable int accountToUnblockId) {
+        accountService.unblockAccount(loggedInId, accountToUnblockId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/EventController.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/EventController.java
@@ -61,11 +61,12 @@ public class EventController {
             @RequestParam(required = false) String name,
             @RequestParam(required = false) String sortBy,
             @RequestParam(required = false) String sortDirection,
-            @RequestParam(required = false) Integer accountId
+            @RequestParam(required = false) Integer accountId,
+            @RequestParam(required = false) Boolean initLoad
     ) {
         try {
             PagedResponse<GetEventDTO> response = eventService.getAllEvents(
-                    pageable, eventTypeId, location, maxParticipants, minRating, startDate, endDate, name, sortBy, sortDirection, accountId);
+                    pageable, eventTypeId, location, maxParticipants, minRating, startDate, endDate, name, sortBy, sortDirection, accountId, initLoad);
 
             return ResponseEntity.ok(response);
         } catch (Exception e) {

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/OfferingController.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/controller/OfferingController.java
@@ -31,9 +31,9 @@ public class OfferingController {
     }
 
     @GetMapping(value="/top", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<Collection<GetOfferingDTO>> getTopOfferings() {
+    public ResponseEntity<Collection<GetOfferingDTO>> getTopOfferings(@RequestParam(required = false) Integer accountId) {
         try {
-            List<GetOfferingDTO> offerings = offeringService.findTopOfferings();
+            List<GetOfferingDTO> offerings = offeringService.findTopOfferings(accountId);
 
             return ResponseEntity.ok(offerings);
         } catch (Exception e) {
@@ -90,12 +90,14 @@ public class OfferingController {
             @RequestParam(required = false) String sortBy,
             @RequestParam(required = false) String sortDirection,
             @RequestParam(required = false) Integer accountId,
-            @RequestParam(required = false) Integer providerId
+            @RequestParam(required = false) Integer providerId,
+            @RequestParam(required = false) Boolean initLoad
+
     ){
         try{
             PagedResponse<GetOfferingDTO> offerings = offeringService.getAllOfferings(
                     pageable, isServiceFilter, name, categoryId, location, startPrice,
-                    endPrice, minDiscount, serviceDuration, minRating, isAvailable, sortBy, sortDirection, accountId, providerId);
+                    endPrice, minDiscount, serviceDuration, minRating, isAvailable, sortBy, sortDirection, accountId, providerId, initLoad);
 
 
             return ResponseEntity.ok(offerings);

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/dto/user/BlockStatusDTO.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/dto/user/BlockStatusDTO.java
@@ -1,0 +1,11 @@
+package com.ftn.iss.eventPlanner.dto.user;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class BlockStatusDTO {
+    boolean blocked;
+    public BlockStatusDTO(boolean blocked) {this.blocked = blocked;}
+}

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/model/Account.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/model/Account.java
@@ -46,7 +46,7 @@ public class Account implements UserDetails {
     private Set<Offering> favouriteOfferings = new HashSet<>();;
     @OneToMany
     private Set<Notification> notifications = new HashSet<>();;
-    @ManyToMany
+    @ManyToMany(fetch = FetchType.LAZY)
     private Set<Account> blockedAccounts = new HashSet<>();;
 
     public Account() {
@@ -94,4 +94,17 @@ public class Account implements UserDetails {
     public boolean isEnabled() {
         return status == AccountStatus.ACTIVE;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Account that)) return false;
+        return  this.id == that.id;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
 }

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/model/specification/EventSpecification.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/model/specification/EventSpecification.java
@@ -1,8 +1,11 @@
 package com.ftn.iss.eventPlanner.model.specification;
+import com.ftn.iss.eventPlanner.model.Account;
 import com.ftn.iss.eventPlanner.model.EventStats;
 import com.ftn.iss.eventPlanner.model.Product;
 import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.JoinType;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
 import org.springframework.data.jpa.domain.Specification;
 import com.ftn.iss.eventPlanner.model.Event;
 
@@ -62,4 +65,45 @@ public class EventSpecification {
     public static Specification<Event> isNotDeleted() {
         return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("isDeleted"), false);
     }
+
+    public static Specification<Event> isNotBlocked(Integer accountId) {
+        return (root, query, cb) -> {
+            if (accountId == null) {
+                return cb.conjunction();
+            }
+
+            Subquery<Integer> subquery = query.subquery(Integer.class);
+            Root<Account> organizerAccount = subquery.from(Account.class);
+            Join<Account, Account> blockedAccounts = organizerAccount.join("blockedAccounts");
+
+            subquery.select(organizerAccount.get("id"))
+                    .where(
+                            cb.equal(organizerAccount, root.get("organizer").get("account")),
+                            cb.equal(blockedAccounts.get("id"), accountId)
+                    );
+
+            return cb.not(cb.exists(subquery));
+        };
+    }
+
+    public static Specification<Event> organizerNotBlocked(Integer accountId) {
+        return (root, query, cb) -> {
+            if (accountId == null) {
+                return cb.conjunction();
+            }
+
+            Subquery<Integer> subquery = query.subquery(Integer.class);
+            Root<Account> userAccount = subquery.from(Account.class);
+            Join<Account, Account> blockedAccounts = userAccount.join("blockedAccounts");
+
+            subquery.select(userAccount.get("id"))
+                    .where(
+                            cb.equal(userAccount.get("id"), accountId),
+                            cb.equal(blockedAccounts.get("id"), root.get("organizer").get("account").get("id"))
+                    );
+
+            return cb.not(cb.exists(subquery));
+        };
+    }
+
 }

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/model/specification/EventSpecification.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/model/specification/EventSpecification.java
@@ -1,7 +1,6 @@
 package com.ftn.iss.eventPlanner.model.specification;
 import com.ftn.iss.eventPlanner.model.Account;
 import com.ftn.iss.eventPlanner.model.EventStats;
-import com.ftn.iss.eventPlanner.model.Product;
 import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Root;
@@ -10,7 +9,6 @@ import org.springframework.data.jpa.domain.Specification;
 import com.ftn.iss.eventPlanner.model.Event;
 
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 
 public class EventSpecification {
 
@@ -66,7 +64,7 @@ public class EventSpecification {
         return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("isDeleted"), false);
     }
 
-    public static Specification<Event> isNotBlocked(Integer accountId) {
+    public static Specification<Event> organizerHasNotBlockedAccount(Integer accountId) {
         return (root, query, cb) -> {
             if (accountId == null) {
                 return cb.conjunction();
@@ -86,7 +84,7 @@ public class EventSpecification {
         };
     }
 
-    public static Specification<Event> organizerNotBlocked(Integer accountId) {
+    public static Specification<Event> accountHasNotBlockedOrganizer(Integer accountId) {
         return (root, query, cb) -> {
             if (accountId == null) {
                 return cb.conjunction();

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/model/specification/ProductSpecification.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/model/specification/ProductSpecification.java
@@ -99,7 +99,7 @@ public class ProductSpecification {
                         : criteriaBuilder.conjunction();
     }
 
-    public static Specification<Product> isNotBlocked(Integer accountId) {
+    public static Specification<Product> providerHasNotBlockedAccount(Integer accountId) {
         return (root, query, cb) -> {
             if (accountId == null) {
                 return cb.conjunction();
@@ -118,7 +118,7 @@ public class ProductSpecification {
             return cb.not(cb.exists(subquery));
         };
     }
-    public static Specification<Product> providerNotBlocked(Integer accountId) {
+    public static Specification<Product> accountHasNotBlockedProvider(Integer accountId) {
         return (root, query, cb) -> {
             if (accountId == null) {
                 return cb.conjunction();

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/model/specification/ServiceSpecification.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/model/specification/ServiceSpecification.java
@@ -118,7 +118,7 @@ public class ServiceSpecification {
                         : criteriaBuilder.conjunction();
     }
 
-    public static Specification<Service> isNotBlocked(Integer accountId) {
+    public static Specification<Service> providerHasNotBlockedAccount(Integer accountId) {
         return (root, query, cb) -> {
             if (accountId == null) {
                 return cb.conjunction();
@@ -138,7 +138,7 @@ public class ServiceSpecification {
         };
     }
 
-    public static Specification<Service> providerNotBlocked(Integer accountId) {
+    public static Specification<Service> accountHasNotBlockedProvider(Integer accountId) {
         return (root, query, cb) -> {
             if (accountId == null) {
                 return cb.conjunction();

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/model/specification/ServiceSpecification.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/model/specification/ServiceSpecification.java
@@ -1,7 +1,7 @@
 package com.ftn.iss.eventPlanner.model.specification;
 
+import com.ftn.iss.eventPlanner.model.Account;
 import com.ftn.iss.eventPlanner.model.Comment;
-import com.ftn.iss.eventPlanner.model.Product;
 import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Root;
@@ -116,5 +116,45 @@ public class ServiceSpecification {
                 providerId != null
                         ? criteriaBuilder.equal(root.get("provider").get("id"), providerId)
                         : criteriaBuilder.conjunction();
+    }
+
+    public static Specification<Service> isNotBlocked(Integer accountId) {
+        return (root, query, cb) -> {
+            if (accountId == null) {
+                return cb.conjunction();
+            }
+
+            Subquery<Integer> subquery = query.subquery(Integer.class);
+            Root<Account> providerAccount = subquery.from(Account.class);
+            Join<Account, Account> blockedAccounts = providerAccount.join("blockedAccounts");
+
+            subquery.select(providerAccount.get("id"))
+                    .where(
+                            cb.equal(providerAccount, root.get("provider").get("account")),
+                            cb.equal(blockedAccounts.get("id"), accountId)
+                    );
+
+            return cb.not(cb.exists(subquery));
+        };
+    }
+
+    public static Specification<Service> providerNotBlocked(Integer accountId) {
+        return (root, query, cb) -> {
+            if (accountId == null) {
+                return cb.conjunction();
+            }
+
+            Subquery<Integer> subquery = query.subquery(Integer.class);
+            Root<Account> userAccount = subquery.from(Account.class);
+            Join<Account, Account> blockedAccounts = userAccount.join("blockedAccounts");
+
+            subquery.select(userAccount.get("id"))
+                    .where(
+                            cb.equal(userAccount.get("id"), accountId),
+                            cb.equal(blockedAccounts.get("id"), root.get("provider").get("account").get("id"))
+                    );
+
+            return cb.not(cb.exists(subquery));
+        };
     }
 }

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/repositories/AccountRepository.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/repositories/AccountRepository.java
@@ -22,4 +22,10 @@ public interface AccountRepository extends JpaRepository<Account, Integer> {
 
     @Query("SELECT a FROM Account a JOIN a.acceptedEvents e WHERE e.id = :eventId")
     List<Account> findAccountsByAcceptedEventId(@Param("eventId") int eventId);
+
+    @Query("SELECT a FROM Account a LEFT JOIN FETCH a.blockedAccounts WHERE a.id = :id")
+    Optional<Account> findByIdWithBlockedAccounts(@Param("id") int id);
+
+    @Query("SELECT COUNT(b) > 0 FROM Account a JOIN a.blockedAccounts b WHERE a.id = :loggedInId AND b.id = :targetId")
+    boolean isBlocked(int loggedInId, int targetId);
 }

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/services/EventService.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/services/EventService.java
@@ -87,6 +87,8 @@ public class EventService {
                 .map(this::mapToGetEventDTO)
                 .collect(Collectors.toList());
     }
+
+    @Transactional
     public PagedResponse<GetEventDTO> getAllEvents(
             Pageable pageable,
             Integer eventTypeId,
@@ -98,9 +100,10 @@ public class EventService {
             String name,
             String sortBy,
             String sortDirection,
-            Integer accountId
+            Integer accountId,
+            Boolean initLoad
     ) {
-        if (accountId != null && (location == null || location.isEmpty())) {
+        if (accountId != null && (location == null || location.isEmpty()) && initLoad != null) {
             Location userLocation = accountService.findUserLocation(accountId);
             if (userLocation != null) {
                 location = userLocation.getCity();
@@ -133,7 +136,9 @@ public class EventService {
                 .and(EventSpecification.minAverageRating(minRating))
                 .and(EventSpecification.hasName(name))
                 .and(EventSpecification.isOpen())
-                .and(EventSpecification.isNotDeleted());
+                .and(EventSpecification.isNotDeleted())
+                .and(EventSpecification.isNotBlocked(accountId))
+                .and(EventSpecification.organizerNotBlocked(accountId));
 
         Page<Event> pagedEvents = eventRepository.findAll(specification, pageable);
 
@@ -156,6 +161,7 @@ public class EventService {
         return eventDTOs;
     }
 
+    @Transactional
     public List<GetEventDTO> findTopEvents(Integer accountId) {
         List<Event> events = eventRepository.findAll();
 
@@ -173,6 +179,18 @@ public class EventService {
 
         return events.stream()
                 .filter(Event::isOpen)
+                .filter(event -> event.getOrganizer().getAccount().getBlockedAccounts()
+                        .stream()
+                        .noneMatch(blockedAcc -> blockedAcc.getId() == accountId))
+                .filter(event -> {
+                    Optional<Account> currentUserOpt = accountRepository.findById(accountId);
+                    if (currentUserOpt.isEmpty()) return true;
+
+                    Account currentUser = currentUserOpt.get();
+                    return currentUser.getBlockedAccounts()
+                            .stream()
+                            .noneMatch(blocked -> blocked.getId() == event.getOrganizer().getAccount().getId());
+                })
                 .sorted((e1, e2) -> e2.getDateCreated().compareTo(e1.getDateCreated()))
                 .limit(5)
                 .map(this::mapToGetEventDTO)

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/services/EventService.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/services/EventService.java
@@ -137,8 +137,8 @@ public class EventService {
                 .and(EventSpecification.hasName(name))
                 .and(EventSpecification.isOpen())
                 .and(EventSpecification.isNotDeleted())
-                .and(EventSpecification.isNotBlocked(accountId))
-                .and(EventSpecification.organizerNotBlocked(accountId));
+                .and(EventSpecification.organizerHasNotBlockedAccount(accountId))
+                .and(EventSpecification.accountHasNotBlockedOrganizer(accountId));
 
         Page<Event> pagedEvents = eventRepository.findAll(specification, pageable);
 

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/services/OfferingService.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/services/OfferingService.java
@@ -152,8 +152,8 @@ public class OfferingService {
                     .and(ServiceSpecification.isAvailable(searchByAvailability))
                     .and(ServiceSpecification.hasProviderId(providerId))
                     .and(ServiceSpecification.isNotDeleted())
-                    .and(ServiceSpecification.isNotBlocked(accountId))
-                    .and(ServiceSpecification.providerNotBlocked(accountId));
+                    .and(ServiceSpecification.providerHasNotBlockedAccount(accountId))
+                    .and(ServiceSpecification.accountHasNotBlockedProvider(accountId));
 
             if(providerId == null){
                 serviceSpecification = serviceSpecification.and(ServiceSpecification.isVisible())
@@ -172,8 +172,8 @@ public class OfferingService {
                     .and(ProductSpecification.isAvailable(searchByAvailability))
                     .and(ProductSpecification.hasProviderId(providerId))
                     .and(ProductSpecification.isNotDeleted())
-                    .and(ProductSpecification.isNotBlocked(accountId))
-                    .and(ProductSpecification.providerNotBlocked(accountId));
+                    .and(ProductSpecification.providerHasNotBlockedAccount(accountId))
+                    .and(ProductSpecification.accountHasNotBlockedProvider(accountId));
 
             if(providerId == null){
                 productSpecification = productSpecification.and(ProductSpecification.isVisible())
@@ -186,14 +186,14 @@ public class OfferingService {
             Specification<Service> serviceSpecification = Specification.where(ServiceSpecification.hasProviderId(providerId))
                     .and(ServiceSpecification.isNotDeleted())
                     .and(ServiceSpecification.hasLocation(location, providerId))
-                    .and(ServiceSpecification.isNotBlocked(accountId))
-                    .and(ServiceSpecification.providerNotBlocked(accountId));
+                    .and(ServiceSpecification.providerHasNotBlockedAccount(accountId))
+                    .and(ServiceSpecification.accountHasNotBlockedProvider(accountId));
 
             Specification<Product> productSpecification = Specification.where(ProductSpecification.hasProviderId(providerId))
                     .and(ProductSpecification.isNotDeleted())
                     .and(ProductSpecification.hasLocation(location, providerId))
-                    .and(ProductSpecification.isNotBlocked(accountId))
-                    .and(ProductSpecification.providerNotBlocked(accountId));
+                    .and(ProductSpecification.providerHasNotBlockedAccount(accountId))
+                    .and(ProductSpecification.accountHasNotBlockedProvider(accountId));
 
             if(providerId == null){
                 serviceSpecification = serviceSpecification.and(ServiceSpecification.isVisible())

--- a/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/services/OfferingService.java
+++ b/eventPlanner/src/main/java/com/ftn/iss/eventPlanner/services/OfferingService.java
@@ -108,9 +108,10 @@ public class OfferingService {
             String sortBy,
             String sortDirection,
             Integer accountId,
-            Integer providerId
+            Integer providerId,
+            Boolean initLoad
     ) {
-        if (accountId != null && (location == null || location.isEmpty())) {
+        if (accountId != null && (location == null || location.isEmpty()) && initLoad != null) {
             Account account = accountRepository.findById(accountId).orElse(null);
             if (account != null && account.getUser() != null){
                 Location userLocation = account.getUser().getLocation();
@@ -150,7 +151,9 @@ public class OfferingService {
                     .and(ServiceSpecification.hasServiceDuration(serviceDuration))
                     .and(ServiceSpecification.isAvailable(searchByAvailability))
                     .and(ServiceSpecification.hasProviderId(providerId))
-                    .and(ServiceSpecification.isNotDeleted());
+                    .and(ServiceSpecification.isNotDeleted())
+                    .and(ServiceSpecification.isNotBlocked(accountId))
+                    .and(ServiceSpecification.providerNotBlocked(accountId));
 
             if(providerId == null){
                 serviceSpecification = serviceSpecification.and(ServiceSpecification.isVisible())
@@ -168,7 +171,9 @@ public class OfferingService {
                     .and(ProductSpecification.minRating(minRating))
                     .and(ProductSpecification.isAvailable(searchByAvailability))
                     .and(ProductSpecification.hasProviderId(providerId))
-                    .and(ProductSpecification.isNotDeleted());
+                    .and(ProductSpecification.isNotDeleted())
+                    .and(ProductSpecification.isNotBlocked(accountId))
+                    .and(ProductSpecification.providerNotBlocked(accountId));
 
             if(providerId == null){
                 productSpecification = productSpecification.and(ProductSpecification.isVisible())
@@ -180,11 +185,15 @@ public class OfferingService {
         } else {
             Specification<Service> serviceSpecification = Specification.where(ServiceSpecification.hasProviderId(providerId))
                     .and(ServiceSpecification.isNotDeleted())
-                    .and(ServiceSpecification.hasLocation(location, providerId));
+                    .and(ServiceSpecification.hasLocation(location, providerId))
+                    .and(ServiceSpecification.isNotBlocked(accountId))
+                    .and(ServiceSpecification.providerNotBlocked(accountId));
 
             Specification<Product> productSpecification = Specification.where(ProductSpecification.hasProviderId(providerId))
                     .and(ProductSpecification.isNotDeleted())
-                    .and(ProductSpecification.hasLocation(location, providerId));
+                    .and(ProductSpecification.hasLocation(location, providerId))
+                    .and(ProductSpecification.isNotBlocked(accountId))
+                    .and(ProductSpecification.providerNotBlocked(accountId));
 
             if(providerId == null){
                 serviceSpecification = serviceSpecification.and(ServiceSpecification.isVisible())
@@ -228,10 +237,22 @@ public class OfferingService {
     }
 
     @Transactional(readOnly = true)
-    public List<GetOfferingDTO> findTopOfferings() {
+    public List<GetOfferingDTO> findTopOfferings(int accountId) {
         List<Offering> offerings = offeringRepository.findAll();
 
         return offerings.stream()
+                .filter(offering -> offering.getProvider().getAccount().getBlockedAccounts()
+                .stream()
+                .noneMatch(blockedAcc -> blockedAcc.getId() == accountId))
+                .filter(offering -> {
+                    Optional<Account> currentUserOpt = accountRepository.findById(accountId);
+                    if (currentUserOpt.isEmpty()) return true;
+
+                    Account currentUser = currentUserOpt.get();
+                    return currentUser.getBlockedAccounts()
+                            .stream()
+                            .noneMatch(blocked -> blocked.getId() == offering.getProvider().getAccount().getId());
+                })
                 .filter(offering -> {
                     if (offering instanceof Product p) {
                         return p.getCurrentDetails().isVisible()


### PR DESCRIPTION
This PR introduces the ability for users to block and unblock other accounts, affecting the visibility of content on the homepage (top and all events/offerings). It also includes filtering logic updates on the backend to reflect these relationships and prevent blocked users' content from appearing in listings.

* **Block/Unblock Support**

  * `POST /accounts/{loggedInId}/block/{accountToBlockId}`
  * `DELETE /accounts/{loggedInId}/unblock/{accountToUnblockId}`
  * `GET /accounts/{loggedInId}/blocked-accounts/{accountToBlockId}` – returns `BlockStatusDTO`
* Added `blockedAccounts` field in `Account` entity with `@ManyToMany` relationship
* Implemented `BlockStatusDTO` for frontend communication

#### Backend Filtering Enhancements

* **Event and Offering listings**

  * `getAllEvents`, `getAllOfferings`, `getTopEvents`, and `getTopOfferings` now exclude:

    * Items from users blocked by the logged-in user
    * Items from users who have blocked the logged-in user
* Filtering is applied using:

  * `EventSpecification.isNotBlocked()` / `organizerNotBlocked()`
  * `ProductSpecification` and `ServiceSpecification` equivalents

#### Repository Updates

* `AccountRepository.findByIdWithBlockedAccounts(...)`
* `AccountRepository.isBlocked(...)`

####  Minor Changes

* Controller methods updated to support new filtering parameters (`initLoad`, `accountId`)
* Equality and hashCode overridden in `Account` to support proper `Set` behavior